### PR TITLE
✍️ added the missing allele_comments.tsv to ngstar db

### DIFF
--- a/ngmaster/db/pubmlst/ngstar/allele_comments.tsv
+++ b/ngmaster/db/pubmlst/ngstar/allele_comments.tsv
@@ -1,0 +1,3985 @@
+penA	1	
+penA	2	
+penA	3	Type 76 Non Mosaic; NG STAR penA allele: 76.004
+penA	4	
+penA	5	
+penA	6	
+penA	7	
+penA	8	
+penA	9	
+penA	10	
+penA	11	
+penA	12	
+penA	13	
+penA	14	mutations present: V316→T; D345→a; F504→L; G545→S Type X mosaic NG STAR penA allele: 10.001 Penicillin MIC: 2
+penA	15	mutations present: F504→L Type V non-mosaic NG STAR penA allele: 5.003
+penA	16	
+penA	17	mutations present: I312→M: NO; V316→T: NO; D345→a: NO; F504→L: NO; N512→Y: NO; G545→S: NO Type I non-mosaic;  NG STAR penA allele: 1.001
+penA	18	mutations present: D345→a Wild type; non-mosaic NG STAR penA allele: 100.001
+penA	19	Type I non-mosaic; FA1090 NG STAR penA allele: 1.002
+penA	20	mutations present: mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XXII non-mosaic NG STAR penA allele: 22.001 Penicillin MIC: 1
+penA	21	mutations present: F504→L YES; P551→S YES Type XII non-mosaic NG STAR penA allele: 12.001 Penicillin MIC: 32
+penA	22	mutations present: I312→M NO; V316→T NO; D345→a YES; F504→L NO; N512→Y NO; G545→S NO Type XV non-mosaic NG STAR penA allele: 15.001 penicillin MIC: 0.032
+penA	23	mutations present: F504→L Type II non-mosaic NG STAR penA allele: 2.002 Penicillin MIC: 64
+penA	24	
+penA	25	
+penA	26	
+penA	27	
+penA	28	
+penA	29	
+penA	30	
+penA	31	
+penA	32	
+penA	33	
+penA	34	
+penA	35	
+penA	36	
+penA	37	
+penA	38	
+penA	39	
+penA	40	
+penA	41	
+penA	42	
+penA	43	
+penA	44	
+penA	45	
+penA	46	
+penA	47	
+penA	48	
+penA	49	PBP2 motif XXXVIII
+penA	50	
+penA	51	
+penA	52	
+penA	53	
+penA	54	
+penA	55	
+penA	56	
+penA	57	
+penA	58	
+penA	59	
+penA	60	
+penA	61	
+penA	62	
+penA	63	
+penA	64	
+penA	65	
+penA	66	
+penA	67	
+penA	68	
+penA	69	
+penA	70	
+penA	71	
+penA	72	
+penA	73	
+penA	74	
+penA	75	
+penA	76	
+penA	77	
+penA	78	
+penA	79	
+penA	80	
+penA	81	
+penA	82	
+penA	83	
+penA	84	
+penA	85	
+penA	86	
+penA	87	
+penA	88	
+penA	89	
+penA	90	
+penA	91	
+penA	92	
+penA	93	
+penA	94	
+penA	95	
+penA	96	
+penA	97	
+penA	98	
+penA	99	
+penA	100	
+penA	101	
+penA	102	
+penA	103	
+penA	104	
+penA	105	
+penA	106	
+penA	107	
+penA	108	
+penA	109	
+penA	110	
+penA	111	
+penA	112	
+penA	113	
+penA	114	
+penA	115	
+penA	116	
+penA	117	
+penA	118	
+penA	119	
+penA	120	
+penA	121	
+penA	122	
+penA	123	
+penA	124	
+penA	125	
+penA	126	
+penA	127	
+penA	128	
+penA	129	
+penA	130	
+penA	131	
+penA	132	
+penA	133	
+penA	134	
+penA	135	
+penA	136	
+penA	137	
+penA	138	
+penA	139	
+penA	140	
+penA	141	
+penA	142	
+penA	143	
+penA	144	
+penA	145	
+penA	146	
+penA	147	
+penA	148	
+penA	149	
+penA	150	
+penA	151	
+penA	152	
+penA	153	
+penA	154	
+penA	155	
+penA	156	
+penA	157	
+penA	158	
+penA	159	
+penA	160	
+penA	161	
+penA	162	
+penA	163	
+penA	164	
+penA	165	
+penA	166	mutations present: F504→L Type II Non-mosaic NG STAR penA allele: 2.001 penicillin MIC: 0.5
+penA	167	
+penA	168	
+penA	169	
+penA	170	
+penA	171	
+penA	172	
+penA	173	
+penA	174	
+penA	175	
+penA	176	
+penA	177	
+penA	178	
+penA	179	
+penA	180	
+penA	181	
+penA	182	
+penA	183	
+penA	184	
+penA	185	
+penA	186	
+penA	187	
+penA	188	
+penA	189	
+penA	190	
+penA	191	
+penA	192	
+penA	193	
+penA	194	
+penA	195	
+penA	196	
+penA	197	
+penA	198	
+penA	199	
+penA	200	
+penA	201	
+penA	202	
+penA	203	
+penA	204	
+penA	205	
+penA	206	
+penA	207	
+penA	208	
+penA	209	
+penA	210	
+penA	211	
+penA	212	
+penA	213	
+penA	214	
+penA	215	
+penA	216	
+penA	217	
+penA	218	
+penA	219	
+penA	220	
+penA	221	
+penA	222	
+penA	223	
+penA	224	
+penA	225	
+penA	226	
+penA	227	
+penA	228	mutations present: mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XIX non-mosaic NG STAR penA allele: 19.001 Penicillin MIC: 0.5
+penA	229	
+penA	230	
+penA	231	
+penA	232	
+penA	233	
+penA	234	
+penA	235	
+penA	236	
+penA	237	
+penA	238	
+penA	239	
+penA	240	
+penA	241	
+penA	242	
+penA	243	
+penA	244	
+penA	245	
+penA	246	
+penA	247	
+penA	248	
+penA	249	
+penA	250	
+penA	251	
+penA	252	
+penA	253	
+penA	254	
+penA	255	
+penA	256	
+penA	257	
+penA	258	
+penA	259	
+penA	260	
+penA	261	
+penA	262	
+penA	263	
+penA	264	
+penA	265	
+penA	266	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type XXXIV mosaic NG STAR penA allele: 34.001 Penicillin MIC: 1
+penA	267	
+penA	268	
+penA	269	
+penA	270	
+penA	271	
+penA	272	
+penA	273	
+penA	274	
+penA	275	
+penA	276	
+penA	277	
+penA	278	
+penA	279	mutations present: F504→L penA Type XXII Non Mosaic; NG STAR penA allele: 22.007
+penA	280	mutations present: F504→L penA Type XXII Non Mosaic; NG STAR penA allele: 22.008
+penA	281	PBP2 motif XXXIV; mutations present: I312→M; V316→T; D345→a; F504→L; N512→Y; G545→S with additional D101→E mutation penA Type 67 Mosaic; NG STAR penA allele: 67.001
+penA	282	mutations present: F504→L penA Type II Non Mosaic; NG STAR penA allele: 2.007
+penA	283	mutations present: F504→L YES; P551→S YES Type XII non-mosaic NG STAR penA allele: 12.004 Penicillin MIC: 0
+penA	284	mutations present: A501→V YES; F504→L; P551→S  Type XIII non-mosaic  NG STAR penA allele: 13.001 Penicillin MIC: 2
+penA	285	mutations present: F504→L; P551→L Type IX non-mosaic NG STAR penA allele: 9.001 Penicillin MIC: 1
+penA	286	mutations present: A501→V; F504→L; P551→L penA Type XI Non Mosaic; NG STAR penA allele: 11.001
+penA	287	mutations present: mutations present: I312→M NO; V316→T NO; D345→a NO;  A501→T YES; F504→L YES N512→Y NO; G545→S NO Type XVIII non mosaic NG STAR penA allele: 18.001 Penicillin MIC: 256
+penA	288	mutations present: F504→L; P551→S Type V non-mosaic NG STAR penA allele: 5.002 Penicillin MIC: 2
+penA	289	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L NO; N512→Y NO; G545→S NO Type XXXV mosaic NG STAR penA allele: 35.001 Penicillin MIC: 4
+penA	290	mutations present: mutations present: I312→M NO; V316→T NO; D345→a NO; A501→V YES; F504→L YES; N512→Y NO; G545→S NO Type XXI non-mosaic NG STAR penA allele: 21.001 Penicillin MIC: 1
+penA	291	mutations present: mutations present: I312→M NO; V316→T NO; D345→a NO; A501→V YES;F504→L YES; N512→Y NO; G545→S NO Type XLIII non-mosaic NG STAR penA allele: 43.002
+penA	292	mutations present: A501→V; F504→L penA Type 43 Non Mosaic; NG STAR penA allele 43.003
+penA	293	mutations present: F504→L; P551→L penA Type IX Non Mosaic; NG STAR penA allele: 9.002
+penA	294	mutations present: F504→L Type XIV non-mosaic NG STAR penA allele: 14.001 Penicillin MIC: 0.25
+penA	295	
+penA	296	
+penA	297	
+penA	298	
+penA	299	
+penA	300	
+penA	301	
+penA	302	
+penA	303	
+penA	304	
+penA	305	
+penA	306	
+penA	307	
+penA	308	
+penA	309	
+penA	310	
+penA	311	
+penA	312	
+penA	313	
+penA	314	
+penA	315	
+penA	316	
+penA	317	
+penA	318	
+penA	319	
+penA	320	
+penA	321	
+penA	322	
+penA	323	
+penA	324	
+penA	325	
+penA	326	
+penA	327	
+penA	328	
+penA	329	
+penA	330	
+penA	331	
+penA	332	
+penA	333	
+penA	334	
+penA	335	
+penA	336	
+penA	337	
+penA	338	
+penA	339	
+penA	340	
+penA	341	
+penA	342	
+penA	343	
+penA	344	
+penA	345	
+penA	346	
+penA	347	
+penA	348	
+penA	349	
+penA	350	
+penA	351	
+penA	352	
+penA	353	
+penA	354	Type 173 Semi Mosaic; NG STAR penA allele: 173.001
+penA	355	
+penA	356	
+penA	357	mutations present: F504→L; N512→Y PenA Type 66 Non Mosaic; NG STAR penA allele: 66.001
+penA	358	
+penA	359	
+penA	360	
+penA	361	
+penA	362	
+penA	363	
+penA	364	
+penA	365	
+penA	366	
+penA	367	
+penA	368	
+penA	369	
+penA	370	
+penA	371	
+penA	372	
+penA	373	
+penA	374	
+penA	375	
+penA	376	
+penA	377	
+penA	378	
+penA	379	
+penA	380	
+penA	381	
+penA	382	
+penA	383	
+penA	384	
+penA	385	
+penA	386	
+penA	387	
+penA	388	
+penA	389	
+penA	390	
+penA	391	
+penA	392	penA Type 105 Mosaic NG STAR penA allele: 105.001
+penA	393	
+penA	394	
+penA	395	
+penA	396	
+penA	397	
+penA	398	
+penA	399	
+penA	400	
+penA	401	
+penA	402	
+penA	403	
+penA	404	
+penA	405	
+penA	406	
+penA	407	
+penA	408	
+penA	409	
+penA	410	
+penA	411	
+penA	412	
+penA	413	
+penA	414	
+penA	415	
+penA	416	
+penA	417	
+penA	418	
+penA	419	
+penA	420	
+penA	421	
+penA	422	
+penA	423	
+penA	424	
+penA	425	
+penA	426	
+penA	427	
+penA	428	
+penA	429	
+penA	430	
+penA	431	
+penA	432	
+penA	433	
+penA	434	
+penA	435	
+penA	436	
+penA	437	
+penA	438	
+penA	439	
+penA	440	
+penA	441	
+penA	442	
+penA	443	
+penA	444	
+penA	445	
+penA	446	
+penA	447	
+penA	448	
+penA	449	
+penA	450	
+penA	451	
+penA	452	
+penA	453	
+penA	454	
+penA	455	
+penA	456	
+penA	457	
+penA	458	
+penA	459	
+penA	460	
+penA	461	
+penA	462	
+penA	463	
+penA	464	
+penA	465	
+penA	466	
+penA	467	
+penA	468	
+penA	469	
+penA	470	
+penA	471	
+penA	472	
+penA	473	
+penA	474	
+penA	475	
+penA	476	
+penA	477	
+penA	478	
+penA	479	
+penA	480	
+penA	481	
+penA	482	
+penA	483	
+penA	484	
+penA	485	
+penA	486	
+penA	487	
+penA	488	
+penA	489	
+penA	490	
+penA	491	
+penA	492	
+penA	493	
+penA	494	mutations present: F504→L Type IV non mosaic NG STAR penA allele: 4.001 Penicillin MIC: 1
+penA	495	
+penA	496	
+penA	497	
+penA	498	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES penA Type XXXIV Mosaic; NG STAR penA allele: 34.009
+penA	499	
+penA	500	mutations present: I312→M YES; V316→T YES; D345→a YES; A501→P YES; F504→L YES; N512→Y YES; G545→S YES Type XLII mosaic NG STAR penA allele: 42.001 Penicillin MIC: 2
+penA	501	
+penA	502	F504→L; P551→S penA Type XII Non Mosaic; NG STAR penA allele 12.005
+penA	503	
+penA	504	mutations present: F504→L penA Type 68 Non Mosaic; NG STAR penA allele: 68.001
+penA	505	
+penA	506	
+penA	507	mutations present: F504→L Type II non-mosaic NG STAR penA allele: 2.006 Penicillin MIC: 0
+penA	508	
+penA	509	mutations present: F504→L penA Type 69 Non Mosaic; NG STAR penA allele 69.001
+penA	510	
+penA	511	penA Type X Mosaic NG STAR penA allele: 10.002
+penA	512	
+penA	513	mutations present: F504→L penA Type XXII Non Mosaic; NG STAR penA allele: 22.009
+penA	514	
+penA	515	mutations present: F504→L penA Type II Non Mosaic; NG STAR penA allele: 2.008
+penA	516	
+penA	517	Type VII non-mosaic NG STAR penA allele: 7.001 Penicillin MIC: 2
+penA	518	
+penA	519	mutations present: F504→L penA Type II Non Mosaic; NG STAR penA allele: 2.009
+penA	520	
+penA	521	
+penA	522	
+penA	523	mutations present: F504→L penA Type 70 Non Mosaic; NG STAR penA allele: 70.001
+penA	524	
+penA	525	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES penA Type 71 Mosaic; NG STAR penA allele: 71.001
+penA	526	
+penA	527	mutations present: D345→a penA WT Non Mosaic; NG STAR penA allele: 100.002
+penA	528	
+penA	529	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XLIII non-mosaic NG STAR penA allele: 43.001 Penicillin MIC: 2
+penA	530	
+penA	531	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES penA Type 72 Mosaic; NG STAR penA allele: 72.001
+penA	532	Type XXXIV mosaic NG STAR penA allele: 34.031
+penA	533	mutations present: D345→a  penA WT Non Mosaic;  NG STAR penA allele: 100.003
+penA	534	mutations present: F504→L penA Type II Non Mosaic; NG STAR penA allele: 2.010
+penA	535	mutations present: F504→L penA Type II Non Mosaic; NG STAR penA allele: 2.011
+penA	536	mutations present: D345→a penA  WT Non Mosaic;  NG STAR penA allele: 100.004
+penA	537	mutations present: D345→a  penA WT Non Mosaic;  NG STAR penA allele: 100.005
+penA	538	mutations present: D345→a penA Type XV Non Mosaic; NG STAR penA allele: 15.003
+penA	539	mutations present: D345→a penA WT Non Mosaic;  NG STAR penA allele: 100.006
+penA	540	
+penA	541	
+penA	542	
+penA	543	mutations present: F504→L; N512→Y penA Type 73 Semi Mosaic; NG STAR penA allele: 73.001
+penA	544	mutations present: D345→a; F504→L penA Type 74 Mosaic; NG STAR penA allele: 74.001
+penA	545	mutations present: I312→M YES; V316→P YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type XXXVII mosaic NG STAR penA allele: 37.001 Penicillin MIC: 4
+penA	546	mutations present: F504→L penA Type II Non Mosaic; NG STAR penA allele: 2.012
+penA	547	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES penA Type 75 Mosaic; NG STAR penA allele: 75.001
+penA	548	
+penA	549	
+penA	550	
+penA	551	
+penA	552	
+penA	553	
+penA	554	
+penA	555	
+penA	556	
+penA	557	
+penA	558	
+penA	559	
+penA	560	
+penA	561	
+penA	562	
+penA	563	
+penA	564	
+penA	565	
+penA	566	
+penA	567	
+penA	568	
+penA	569	
+penA	570	
+penA	571	
+penA	572	
+penA	573	
+penA	574	
+penA	575	
+penA	576	
+penA	577	
+penA	578	
+penA	579	
+penA	580	
+penA	581	
+penA	582	
+penA	583	
+penA	584	
+penA	585	
+penA	586	
+penA	587	
+penA	588	
+penA	589	
+penA	590	
+penA	591	
+penA	592	
+penA	593	
+penA	594	
+penA	595	
+penA	596	
+penA	597	
+penA	598	
+penA	599	
+penA	600	
+penA	601	
+penA	602	
+penA	603	
+penA	604	
+penA	605	
+penA	606	
+penA	607	
+penA	608	
+penA	609	
+penA	610	
+penA	611	
+penA	612	
+penA	613	
+penA	614	
+penA	615	
+penA	616	
+penA	617	
+penA	618	
+penA	619	
+penA	620	
+penA	621	
+penA	622	
+penA	623	
+penA	624	
+penA	625	
+penA	626	
+penA	627	
+penA	628	
+penA	629	
+penA	630	
+penA	631	
+penA	632	
+penA	633	
+penA	634	
+penA	635	
+penA	636	
+penA	637	
+penA	638	
+penA	639	
+penA	640	
+penA	641	
+penA	642	
+penA	643	
+penA	644	
+penA	645	mutations present: I312→M NO; V316→T NO; D345→a NO; A501→T YES; F504→L YES; N512→Y NO; G545→S NO; P551→S/L YES Type XLIV non-mosaic NG STAR penA allele: 44.001 Penicillin MIC: 1
+penA	646	
+penA	647	
+penA	648	
+penA	649	
+penA	650	
+penA	651	
+penA	652	
+penA	653	
+penA	654	
+penA	655	
+penA	656	
+penA	657	
+penA	658	
+penA	659	
+penA	660	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES penA Type XXXIV Mosaic; NG STAR penA allele: 34.01
+penA	661	mutations present: D345→a penA Type 76 Non Mosaic; NG STAR penA allele: 76.001
+penA	662	mutations present: F504→L penA Type IX Non Mosaic; NG STAR penA allele: 9.003
+penA	663	mutations present: F504→L penA Type IX Non Mosaic; NG STAR penA allele: 9.004
+penA	664	mutations present: F504→L penA Type 77 Non Mosaic; NG STAR penA allele: 77.001
+penA	665	mutations present: I312→M NO; V316→T NO; D345→a YES; F504→L YES; N512→Y NO; G545→S NO Type XLV non-mosaic NG STAR penA allele: 45.001 Penicillin MIC: 0.125
+penA	666	mutations present: F504→L penA Type XXII Non Mosaic; NG STAR allele: 22.01
+penA	667	mutations present: F504→L penA Type IX Non Mosaic; NG STAR penA allele: 9.005
+penA	668	mutations present: F504→L; N512→Y NG STAR allele: 78.001 penA Type 78 Semi-Mosaic
+penA	669	NEIS1753
+penA	670	mutations present: D345→a NG STAR allele: 79.001 penA Type 79 NonMosaic
+penA	671	mutations present: F504→L penA Type XII Non Mosaic; NG STAR penA allele: 12.006
+penA	672	
+penA	673	
+penA	674	
+penA	675	
+penA	676	
+penA	677	
+penA	678	NEIS1753
+penA	679	
+penA	680	NEIS1753
+penA	681	NEIS1753
+penA	682	NEIS1753
+penA	683	NEIS1753
+penA	684	NEIS1753
+penA	685	NEIS1753
+penA	686	
+penA	687	
+penA	688	
+penA	689	
+penA	690	
+penA	691	
+penA	692	NEIS1753
+penA	693	NEIS1753
+penA	694	NEIS1753
+penA	695	NEIS1753
+penA	696	NEIS1753
+penA	697	NEIS1753
+penA	698	NEIS1753
+penA	699	NEIS1753
+penA	700	NEIS1753
+penA	701	NEIS1753
+penA	702	NEIS1753
+penA	703	
+penA	704	NEIS1753
+penA	705	NEIS1753
+penA	706	NEIS1753
+penA	707	NEIS1753
+penA	708	NEIS1753
+penA	709	NEIS1753
+penA	710	NEIS1753
+penA	711	NEIS1753
+penA	712	penA Type 94 NonMosaic NG STAR allele: 94.001
+penA	713	NEIS1753
+penA	714	NEIS1753
+penA	715	NEIS1753
+penA	716	NEIS1753
+penA	717	NEIS1753
+penA	718	NEIS1753
+penA	719	NEIS1753
+penA	720	NEIS1753
+penA	721	NEIS1753
+penA	722	NEIS1753
+penA	723	NEIS1753
+penA	724	NEIS1753
+penA	725	NEIS1753
+penA	726	NEIS1753
+penA	727	NEIS1753
+penA	728	NEIS1753
+penA	729	NEIS1753
+penA	730	NEIS1753
+penA	731	NEIS1753
+penA	732	NEIS1753
+penA	733	NEIS1753
+penA	734	
+penA	735	NEIS0021
+penA	736	NEIS0021
+penA	737	
+penA	738	
+penA	739	
+penA	740	
+penA	741	
+penA	742	
+penA	743	
+penA	744	
+penA	745	
+penA	746	
+penA	747	
+penA	748	
+penA	749	
+penA	750	
+penA	751	
+penA	752	
+penA	753	
+penA	754	
+penA	755	
+penA	756	
+penA	757	
+penA	758	
+penA	759	
+penA	760	
+penA	761	
+penA	762	
+penA	763	
+penA	764	
+penA	765	
+penA	766	
+penA	767	
+penA	768	
+penA	769	
+penA	770	
+penA	771	
+penA	772	
+penA	773	
+penA	774	
+penA	775	
+penA	776	
+penA	777	
+penA	778	
+penA	779	
+penA	780	
+penA	781	
+penA	782	
+penA	783	
+penA	784	
+penA	785	
+penA	786	
+penA	787	
+penA	788	
+penA	789	
+penA	790	
+penA	791	
+penA	792	
+penA	793	
+penA	794	
+penA	795	
+penA	796	
+penA	797	
+penA	798	
+penA	799	
+penA	800	
+penA	801	
+penA	802	
+penA	803	
+penA	804	
+penA	805	
+penA	806	
+penA	807	
+penA	808	
+penA	809	
+penA	810	
+penA	811	
+penA	812	
+penA	813	mutations present: F504→L penA Type 80 Semi Mosaic; NG STAR penA allele: 80.001
+penA	814	N. elongata allele
+penA	815	mutations present: I312→M YES;V316→T YES; D345→a YES; A501→V/P NO;   F504→L YES; N512→Y NO; G545→S NO; P551→S/L NO penA Type 131 Mosaic NG STAR penA allele: 131.001
+penA	816	
+penA	817	
+penA	818	
+penA	819	
+penA	820	
+penA	821	
+penA	822	
+penA	823	
+penA	824	
+penA	825	
+penA	826	
+penA	827	
+penA	828	
+penA	829	
+penA	830	
+penA	831	
+penA	832	
+penA	833	
+penA	834	
+penA	835	
+penA	836	
+penA	837	
+penA	838	
+penA	839	
+penA	840	
+penA	841	
+penA	842	
+penA	843	
+penA	844	
+penA	845	
+penA	846	
+penA	847	
+penA	848	
+penA	849	
+penA	850	
+penA	851	
+penA	852	
+penA	853	
+penA	854	penA Type II NonMosaic NG STAR allele: 2.019
+penA	855	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XLI non-mosaic NG STAR penA allele: 41.001 Penicillin MIC 2
+penA	856	
+penA	857	
+penA	858	
+penA	859	
+penA	860	
+penA	861	
+penA	862	
+penA	863	
+penA	864	
+penA	865	
+penA	866	
+penA	867	
+penA	868	
+penA	869	
+penA	870	
+penA	871	
+penA	872	
+penA	873	Type LIV Non-Mosaic NG STAR penA allele: 54.002
+penA	874	NG STAR allele: 100.01 penA WT NonMosaic
+penA	875	mutations present: A501→V; penA Type XIII NonMosaic;  NG STAR penA allele: 13.002
+penA	876	Type XII non-mosaic NG STAR penA allele: 12.002 Penicillin MIC: 4
+penA	877	Type XIV non-mosaic NG STAR penA allele: 14.012; A517G
+penA	878	Type XIII non-mosaic NG STAR penA allele: 13.005; A501V, A517G
+penA	879	Type XXXIV mosaic NG STAR penA allele: 34.022
+penA	880	
+penA	881	
+penA	882	Type XLIII non-mosaic NG STAR penA allele: 43.005
+penA	883	
+penA	884	
+penA	885	
+penA	886	
+penA	887	
+penA	888	
+penA	889	
+penA	890	
+penA	891	
+penA	892	
+penA	893	
+penA	894	
+penA	895	
+penA	896	
+penA	897	
+penA	898	
+penA	899	
+penA	900	
+penA	901	
+penA	902	
+penA	903	
+penA	904	
+penA	905	
+penA	906	
+penA	907	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y NO; G545→S NO
+penA	908	mutations present: I312→M NO; V316→T NO; D345→a YES; F504→L YES; N512→Y YES; G545→S NO
+penA	909	
+penA	910	
+penA	911	
+penA	912	
+penA	913	
+penA	914	
+penA	915	
+penA	916	
+penA	917	
+penA	918	
+penA	919	
+penA	920	
+penA	921	
+penA	922	
+penA	923	
+penA	924	
+penA	925	
+penA	926	
+penA	927	
+penA	928	
+penA	929	
+penA	930	
+penA	931	
+penA	932	
+penA	933	
+penA	934	
+penA	935	
+penA	936	
+penA	937	
+penA	938	
+penA	939	
+penA	940	
+penA	941	
+penA	942	
+penA	943	
+penA	944	
+penA	945	
+penA	946	
+penA	947	
+penA	948	
+penA	949	
+penA	950	
+penA	951	
+penA	952	
+penA	953	
+penA	954	
+penA	955	
+penA	956	
+penA	957	
+penA	958	
+penA	959	
+penA	960	
+penA	961	
+penA	962	
+penA	963	
+penA	964	
+penA	965	
+penA	966	
+penA	967	
+penA	968	
+penA	969	
+penA	970	
+penA	971	
+penA	972	
+penA	973	
+penA	974	
+penA	975	
+penA	976	
+penA	977	
+penA	978	
+penA	979	
+penA	980	
+penA	981	
+penA	982	
+penA	983	
+penA	984	
+penA	985	
+penA	986	
+penA	987	
+penA	988	
+penA	989	
+penA	990	
+penA	991	
+penA	992	
+penA	993	
+penA	994	
+penA	995	
+penA	996	
+penA	997	
+penA	998	
+penA	999	
+penA	1000	
+penA	1001	
+penA	1002	
+penA	1003	
+penA	1004	
+penA	1005	
+penA	1006	
+penA	1007	
+penA	1008	
+penA	1009	
+penA	1010	
+penA	1011	
+penA	1012	
+penA	1013	
+penA	1014	
+penA	1015	
+penA	1016	
+penA	1017	
+penA	1018	
+penA	1019	
+penA	1020	
+penA	1021	
+penA	1022	
+penA	1023	
+penA	1024	
+penA	1025	
+penA	1026	
+penA	1027	
+penA	1028	
+penA	1029	
+penA	1030	
+penA	1031	
+penA	1032	
+penA	1033	
+penA	1034	
+penA	1035	
+penA	1036	
+penA	1037	
+penA	1038	
+penA	1039	
+penA	1040	
+penA	1041	
+penA	1042	
+penA	1043	
+penA	1044	
+penA	1045	
+penA	1046	
+penA	1047	
+penA	1048	
+penA	1049	
+penA	1050	
+penA	1051	
+penA	1052	
+penA	1053	
+penA	1054	
+penA	1055	
+penA	1056	
+penA	1057	
+penA	1058	
+penA	1059	
+penA	1060	
+penA	1061	
+penA	1062	
+penA	1063	
+penA	1064	
+penA	1065	
+penA	1066	
+penA	1067	
+penA	1068	
+penA	1069	
+penA	1070	
+penA	1071	
+penA	1072	
+penA	1073	
+penA	1074	
+penA	1075	
+penA	1076	
+penA	1077	
+penA	1078	
+penA	1079	
+penA	1080	
+penA	1081	
+penA	1082	
+penA	1083	
+penA	1084	
+penA	1085	
+penA	1086	
+penA	1087	
+penA	1088	
+penA	1089	
+penA	1090	
+penA	1091	
+penA	1092	
+penA	1093	
+penA	1094	
+penA	1095	Type 76 Non Mosaic; NG STAR penA allele: 76.003
+penA	1096	
+penA	1097	
+penA	1098	
+penA	1099	
+penA	1100	
+penA	1101	
+penA	1102	
+penA	1103	
+penA	1104	
+penA	1105	
+penA	1106	
+penA	1107	
+penA	1108	
+penA	1109	
+penA	1110	
+penA	1111	
+penA	1112	
+penA	1113	
+penA	1114	
+penA	1115	
+penA	1116	
+penA	1117	
+penA	1118	
+penA	1119	
+penA	1120	
+penA	1121	
+penA	1122	
+penA	1123	
+penA	1124	
+penA	1125	
+penA	1126	
+penA	1127	
+penA	1128	
+penA	1129	
+penA	1130	
+penA	1131	
+penA	1132	
+penA	1133	
+penA	1134	
+penA	1135	
+penA	1136	
+penA	1137	
+penA	1138	
+penA	1139	
+penA	1140	
+penA	1141	
+penA	1142	
+penA	1143	
+penA	1144	
+penA	1145	
+penA	1146	
+penA	1147	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y NO; G545→S NO Type LXIII Mosaic NG STAR penA allele: 63.001
+penA	1148	
+penA	1149	
+penA	1150	
+penA	1151	
+penA	1152	
+penA	1153	
+penA	1154	
+penA	1155	
+penA	1156	
+penA	1157	
+penA	1158	
+penA	1159	
+penA	1160	
+penA	1161	
+penA	1162	
+penA	1163	
+penA	1164	
+penA	1165	
+penA	1166	
+penA	1167	
+penA	1168	
+penA	1169	
+penA	1170	
+penA	1171	
+penA	1172	
+penA	1173	
+penA	1174	
+penA	1175	
+penA	1176	
+penA	1177	
+penA	1178	
+penA	1179	
+penA	1180	
+penA	1181	
+penA	1182	
+penA	1183	
+penA	1184	
+penA	1185	
+penA	1186	
+penA	1187	
+penA	1188	
+penA	1189	
+penA	1190	
+penA	1191	
+penA	1192	
+penA	1193	
+penA	1194	
+penA	1195	
+penA	1196	
+penA	1197	
+penA	1198	
+penA	1199	
+penA	1200	
+penA	1201	
+penA	1202	
+penA	1203	
+penA	1204	
+penA	1205	
+penA	1206	
+penA	1207	
+penA	1208	
+penA	1209	
+penA	1210	
+penA	1211	
+penA	1212	
+penA	1213	
+penA	1214	
+penA	1215	
+penA	1216	
+penA	1217	
+penA	1218	
+penA	1219	
+penA	1220	
+penA	1221	
+penA	1222	extracted from Neisseria mucosa C6A I312→M YES; V316→T YES; D345→a NO; F504→L YES; N512→Y NO; G545→S NO
+penA	1223	Mutations present: I312→M NO; V316→T NO; D345→a YES; F504→L YES; N512→Y NO; G545→S NO mosaic II NG STAR penA allele: 87.001 penA Type 87
+penA	1224	I312→M NO; V316→T NO; D345→a YES; F504→L YES; N512→Y NO; G545→S NO mosaic II NG STAR penA allele: 103.003
+penA	1225	
+penA	1226	
+penA	1227	
+penA	1228	
+penA	1229	
+penA	1230	
+penA	1231	
+penA	1232	
+penA	1233	
+penA	1234	mutations present: D345→a; F504→L; N512→Y; penA Type 81 Semi Mosaic; NG STAR penA allele: 81.001
+penA	1235	mutations present: F504→L penA Type II Non Mosaic; NG STAR penA allele: 2.013
+penA	1236	AMR mutations present: none penA Type I Non Mosaic; NG STAR allele: 1.004
+penA	1237	mutations present: D345→a; F504→L;  penA WT Non Mosaic;  NG STAR penA allele:100.007
+penA	1238	mutations present: F504→L; penA Type II Non Mosaic; NG STAR penA allele: 2.014
+penA	1239	AMR mutations present: none penA Type I Non Mosaic; NG STAR penA allele: 1.005
+penA	1240	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type XXXIV mosaic NG STAR penA allele: 34.002 Penicillin MIC: 2
+penA	1241	
+penA	1242	
+penA	1243	
+penA	1244	
+penA	1245	
+penA	1246	
+penA	1247	
+penA	1248	
+penA	1249	
+penA	1250	
+penA	1251	
+penA	1252	
+penA	1253	
+penA	1254	
+penA	1255	
+penA	1256	
+penA	1257	
+penA	1258	
+penA	1259	
+penA	1260	
+penA	1261	
+penA	1262	
+penA	1263	
+penA	1264	
+penA	1265	
+penA	1266	
+penA	1267	
+penA	1268	
+penA	1269	
+penA	1270	
+penA	1271	
+penA	1272	
+penA	1273	
+penA	1274	
+penA	1275	
+penA	1276	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XXII non-mosaic NG STAR penA allele: 22.002 Penicillin MIC: 0.25
+penA	1277	mutations present: D345→a penA Type XV Non Mosaic; NG STAR penA allele: 15.004
+penA	1278	AMR: none penA Type I Non Mosaic; NG STAR penA allele: 1.006
+penA	1279	
+penA	1280	
+penA	1281	
+penA	1282	
+penA	1283	
+penA	1284	
+penA	1285	
+penA	1286	
+penA	1287	
+penA	1288	
+penA	1289	
+penA	1290	
+penA	1291	
+penA	1292	
+penA	1293	
+penA	1294	
+penA	1295	
+penA	1296	
+penA	1297	
+penA	1298	
+penA	1299	
+penA	1300	Type XLIV non-mosaic NG STAR penA allele: 44.005
+penA	1301	Mutations present: A501→V;  penA Type 88 NonMosaic;  NG STAR pen allele: 88.001
+penA	1302	Type XII non-mosaic NG STAR penA allele: 12.009
+penA	1303	Type XIX non-mosaic NG STAR penA allele: 19.011
+penA	1304	penA Type: 2; Non-Mosaic; NG STAR penA allele: 2.024
+penA	1305	
+penA	1306	
+penA	1307	
+penA	1308	
+penA	1309	
+penA	1310	
+penA	1311	
+penA	1312	
+penA	1313	
+penA	1314	
+penA	1315	
+penA	1316	
+penA	1317	
+penA	1318	
+penA	1319	
+penA	1320	mutations present: F504→L penA Type 69 Non Mosaic; NG STAR penA allele: 69.002
+penA	1321	I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XIV non-mosaic NG STAR penA allele: 14.002 penicillin MIC: 0.5
+penA	1322	Type I non-mosaic NG STAR penA allele: 1.003 penA MIC: 0.063
+penA	1323	mutations present: I312→M NO; V316→T NO; D345→a YES; F504→L NO; N512→Y NO; G545→S NO Type XV Non-Mosaic NG STAR penA allele: 15.002 Penicillin MIC: 0.125
+penA	1324	mutations present: F504→L penA Type 44 Non Mosaic; NG STAR penA allele: 44.002
+penA	1325	mutations present: D345→a penA Type 82 Non Mosaic; NG STAR penA allele: 82.001
+penA	1326	mutations present: F504→L penA Type IX Non Mosaic; NG STAR penA allele: 9.006
+penA	1327	no AMR mutations penA Type I Non Mosaic; NG STAR penA allele: 1.007
+penA	1328	mutations present: D345→a  penA WT Non Mosaic;  NG STAR penA allele: 100.008
+penA	1329	mutations present: F504→L penA Type XIV; NG STAR penA allele: 14.004
+penA	1330	mutations present: F504→L penA Type 83 Non Mosaic; NG STAR penA allele: 83.001
+penA	1331	mutations present: D345→a penA Type 79 Non Mosaic; NG STAR penA allele: 79.002
+penA	1332	
+penA	1333	
+penA	1334	
+penA	1335	
+penA	1336	
+penA	1337	
+penA	1338	
+penA	1339	
+penA	1340	
+penA	1341	
+penA	1342	
+penA	1343	
+penA	1344	
+penA	1345	
+penA	1346	
+penA	1347	
+penA	1348	
+penA	1349	
+penA	1350	
+penA	1351	
+penA	1352	
+penA	1353	
+penA	1354	
+penA	1355	
+penA	1356	
+penA	1357	
+penA	1358	
+penA	1359	
+penA	1360	
+penA	1361	
+penA	1362	
+penA	1363	
+penA	1364	
+penA	1365	
+penA	1366	
+penA	1367	
+penA	1368	
+penA	1369	
+penA	1370	
+penA	1371	
+penA	1372	
+penA	1373	
+penA	1374	
+penA	1375	
+penA	1376	
+penA	1377	
+penA	1378	
+penA	1379	
+penA	1380	
+penA	1381	
+penA	1382	
+penA	1383	
+penA	1384	
+penA	1385	
+penA	1386	
+penA	1387	
+penA	1388	
+penA	1389	
+penA	1390	
+penA	1391	
+penA	1392	
+penA	1393	
+penA	1394	
+penA	1395	
+penA	1396	
+penA	1397	
+penA	1398	
+penA	1399	
+penA	1400	
+penA	1401	
+penA	1402	
+penA	1403	
+penA	1404	
+penA	1405	
+penA	1406	
+penA	1407	
+penA	1408	
+penA	1409	
+penA	1410	
+penA	1411	
+penA	1412	
+penA	1413	
+penA	1414	
+penA	1415	
+penA	1416	
+penA	1417	
+penA	1418	
+penA	1419	
+penA	1420	
+penA	1421	
+penA	1422	
+penA	1423	
+penA	1424	
+penA	1425	
+penA	1426	
+penA	1427	
+penA	1428	
+penA	1429	
+penA	1430	
+penA	1431	
+penA	1432	
+penA	1433	
+penA	1434	
+penA	1435	
+penA	1436	
+penA	1437	
+penA	1438	
+penA	1439	
+penA	1440	
+penA	1441	
+penA	1442	Type XIII non-mosaic NG STAR penA allele: 13.006; A501V, A517G
+penA	1443	Type LIII Mosaic NG STAR penA allele: 53.003
+penA	1444	penA Type 93 SemiMosaic NG STAR penA allele: 93.001
+penA	1445	
+penA	1446	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.034
+penA	1447	
+penA	1448	
+penA	1449	
+penA	1450	
+penA	1451	Type 254 Mosaic; N513Y; NG STAR penA allele: 254.001
+penA	1452	
+penA	1453	from genome assembled with SPADES
+penA	1454	
+penA	1455	
+penA	1456	
+penA	1457	
+penA	1458	
+penA	1459	
+penA	1460	
+penA	1461	
+penA	1462	
+penA	1463	
+penA	1464	
+penA	1465	
+penA	1466	
+penA	1467	
+penA	1468	
+penA	1469	
+penA	1470	
+penA	1471	
+penA	1472	
+penA	1473	
+penA	1474	
+penA	1475	
+penA	1476	
+penA	1477	
+penA	1478	
+penA	1479	
+penA	1480	
+penA	1481	
+penA	1482	
+penA	1483	
+penA	1484	
+penA	1485	
+penA	1486	
+penA	1487	
+penA	1488	
+penA	1489	
+penA	1490	
+penA	1491	
+penA	1492	
+penA	1493	
+penA	1494	
+penA	1495	
+penA	1496	
+penA	1497	
+penA	1498	
+penA	1499	
+penA	1500	
+penA	1501	Type XLIV non-mosaic NG STAR penA allele: 44.006
+penA	1502	penA Type II NonMosaic NG STAR penA allele: 2.020
+penA	1503	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; A541→G YES; G545→S YES penA Type XXXIV Mosaic; NG STAR penA allele: 34.008
+penA	1504	
+penA	1505	Type XLV non-mosaic NG STAR penA allele: 45.002
+penA	1506	
+penA	1507	
+penA	1508	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type II non-mosaic NG STAR penA allele: 2.003 Penicillin MIC: 0.25
+penA	1509	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type II non-mosaic NG STAR penA allele: 2.004 Penicillin MIC: 0
+penA	1510	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type II non-mosaic NG STAR penA allele: 2.005 Penicillin MIC: 0
+penA	1511	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO   A501V, A517G NG STAR penA allele: 122.001; Penicillin MIC: 4
+penA	1512	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type V Non-Mosaic NG STAR penA allele: 5.001 Penicillin MIC: 0.5
+penA	1513	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type V Non-Mosaic NG STAR penA allele: 5.004 Penicillin MIC: 1
+penA	1514	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XII Non-Mosaic NG STAR penA allele: 12.003 Penicillin MIC: 4
+penA	1515	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XIV Non-Mosaic NG STAR penA allele: 14.003 Penicillin MIC: 0.05
+penA	1516	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XVII Non-Mosaic NG STAR penA allele: 17.001 Penicillin MIC: 2
+penA	1517	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XXII Non-Mosaic NG STAR penA allele: 22.003 Penicillin MIC: 0.25
+penA	1518	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XXII Non-Mosaic NG STAR penA allele: 22.004 Penicillin MIC: 0.5
+penA	1519	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XXII Non-Mosaic NG STAR penA allele: 22.005 Penicillin MIC: 0.25
+penA	1520	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XXII Non-Mosaic NG STAR penA allele: 22.006 Penicillin MIC: 0.5
+penA	1521	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type XXVII Mosaic NG STAR penA allele: 27.001 Penicillin MIC: 4
+penA	1522	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type XXXIV Mosaic NG STAR penA allele: 34.003 Penicillin MIC: 1
+penA	1523	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; A541→G YES; G545→S YES Type XXXIV Mosaic NG STAR penA allele: 34.004 Penicillin MIC: 2
+penA	1524	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type XXXIV Mosaic NG STAR penA allele: 34.005
+penA	1525	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type XXXIV Mosaic NG STAR penA allele: 34.006 Penicillin MIC: 0.25
+penA	1526	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type XXXIV Mosaic NG STAR penA allele: 34.007 Penicillin MIC: 128
+penA	1527	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y NO; G545→S NO Type XXXV Mosaic NG STAR penA allele: 35.002 Penicillin MIC: 2
+penA	1528	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y NO; G545→S NO Type XXXV Mosaic NG STAR penA allele: 35.003
+penA	1529	mutations present: I312→M NO; V316→T NO; D345→a YES; F504→L YES; N512→Y NO; G545→S NO  Type XXXVIII Mosaic NG STAR penA allele: 38.001 Penicillin MIC: 0.25
+penA	1530	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XXXIX Non-Mosaic NG STAR penA allele: 39.001 Penicillin MIC: 0.5
+penA	1531	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L NO; N512→Y NO; G545→S NO Type XL Non-Mosaic NG STAR penA allele: 40.001 Penicillin MIC: 0.063
+penA	1532	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XLI Non-Mosaic NG STAR penA allele: 41.002 Penicillin MIC: 2
+penA	1533	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XLVI Non-Mosaic NG STAR penA allele: 46.001
+penA	1534	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y NO; G545→S NO Type XLVII semi-Mosaic NG STAR penA allele: 47.001 Penicillin MIC: 0.5
+penA	1535	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XLVIII Non-Mosaic NG STAR penA allele: 48.001 Penicillin MIC: 0.5
+penA	1536	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type XLIX Non-Mosaic NG STAR penA allele: 49.001 Penicillin MIC: 0.5
+penA	1537	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type L Non-Mosaic NG STAR penA allele: 50.001
+penA	1538	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type LI Mosaic NG STAR penA allele: 51.001 Penicillin MIC: 1
+penA	1539	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type LII Mosaic NG STAR penA allele: 52.001 Penicillin MIC: 2
+penA	1540	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type LIII Mosaic NG STAR penA allele: 53.001 Penicillin MIC: 2
+penA	1541	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type LIII Mosaic NG STAR penA allele: 53.002 Penicillin MIC: 4
+penA	1542	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type LIV Non-Mosaic NG STAR penA allele: 54.001 Penicillin MIC: 2
+penA	1543	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type LV Mosaic NG STAR penA allele: 55.001 Penicillin MIC: 4
+penA	1544	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type LVI Non-Mosaic NG STAR penA allele: 56.001 Penicillin MIC: 2
+penA	1545	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type LVII Non-Mosaic NG STAR penA allele: 57.001 Penicillin MIC: 4
+penA	1546	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type LVIII Mosaic NG STAR penA allele: 58.001 Penicillin MIC: 2
+penA	1547	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type LIX Mosaic NG STAR penA allele: 59.001 Penicillin MIC: 2
+penA	1548	mutations present: I312→M NO; V316→T NO; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type LX Mosaic NG STAR penA allele: 60.001
+penA	1549	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO Type LXI Non-Mosaic NG STAR penA allele: 61.001 Penicillin MIC: 2
+penA	1550	mutations present: I312→M NO; V316→T NO; D345→a YES; F504→L YES; N512→Y YES; G545→S NO Type LXII Mosaic NG STAR penA allele: 62.001
+penA	1551	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y YES; G545→S YES Type LXIV Mosaic NG STAR penA allele: 64.001
+penA	1552	
+penA	1553	
+penA	1554	
+penA	1555	
+penA	1556	
+penA	1557	
+penA	1558	
+penA	1559	
+penA	1560	
+penA	1561	
+penA	1562	
+penA	1563	
+penA	1564	
+penA	1565	
+penA	1566	
+penA	1567	
+penA	1568	
+penA	1569	
+penA	1570	
+penA	1571	
+penA	1572	
+penA	1573	
+penA	1574	
+penA	1575	
+penA	1576	
+penA	1577	
+penA	1578	
+penA	1579	
+penA	1580	
+penA	1581	
+penA	1582	
+penA	1583	
+penA	1584	
+penA	1585	
+penA	1586	
+penA	1587	
+penA	1588	
+penA	1589	
+penA	1590	
+penA	1591	
+penA	1592	
+penA	1593	
+penA	1594	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.035
+penA	1595	penA Type III NonMosaic NG STAR penA allele: 3.001
+penA	1596	
+penA	1597	
+penA	1598	
+penA	1599	
+penA	1600	
+penA	1601	
+penA	1602	
+penA	1603	
+penA	1604	
+penA	1605	
+penA	1606	
+penA	1607	Type 168 Mosaic; A501V, N513Y; NG STAR penA allele: 168.001
+penA	1608	penA Type XXXIV Mosaic NG STAR penA allele: 34.011
+penA	1609	
+penA	1610	
+penA	1611	
+penA	1612	penA Type V NonMosaic;  Mutations: A517G and G543S NG STAR penA allele: 5.007
+penA	1613	penA Type: 3; Non-Mosaic; NG STAR penA allele: 3.004
+penA	1614	penA Type 103 NonMosaic; A501→V;  NG STAR penA allele: 103.002
+penA	1615	
+penA	1616	
+penA	1617	
+penA	1618	
+penA	1619	
+penA	1620	
+penA	1621	
+penA	1622	
+penA	1623	
+penA	1624	
+penA	1625	
+penA	1626	
+penA	1627	
+penA	1628	
+penA	1629	
+penA	1630	
+penA	1631	
+penA	1632	
+penA	1633	
+penA	1634	
+penA	1635	
+penA	1636	
+penA	1637	
+penA	1638	
+penA	1639	
+penA	1640	
+penA	1641	
+penA	1642	
+penA	1643	
+penA	1644	
+penA	1645	
+penA	1646	
+penA	1647	
+penA	1648	
+penA	1649	
+penA	1650	
+penA	1651	
+penA	1652	
+penA	1653	
+penA	1654	
+penA	1655	
+penA	1656	
+penA	1657	
+penA	1658	
+penA	1659	
+penA	1660	
+penA	1661	
+penA	1662	
+penA	1663	
+penA	1664	
+penA	1665	
+penA	1666	
+penA	1667	
+penA	1668	
+penA	1669	
+penA	1670	
+penA	1671	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.036
+penA	1672	
+penA	1673	
+penA	1674	
+penA	1675	
+penA	1676	
+penA	1677	
+penA	1678	
+penA	1679	
+penA	1680	
+penA	1681	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.037
+penA	1682	Type L Non-Mosaic NG STAR penA allele: 50.002
+penA	1683	Type XIX non-mosaic NG STAR penA allele: 19.012
+penA	1684	Type V Non-Mosaic NG STAR penA allele: 5.008; A517G G543S
+penA	1685	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.038
+penA	1686	
+penA	1687	
+penA	1688	
+penA	1689	
+penA	1690	
+penA	1691	
+penA	1692	
+penA	1693	
+penA	1694	
+penA	1695	
+penA	1696	
+penA	1697	
+penA	1698	
+penA	1699	
+penA	1700	
+penA	1701	
+penA	1702	
+penA	1703	
+penA	1704	
+penA	1705	
+penA	1706	
+penA	1707	
+penA	1708	
+penA	1709	
+penA	1710	
+penA	1711	
+penA	1712	
+penA	1713	
+penA	1714	
+penA	1715	
+penA	1716	
+penA	1717	
+penA	1718	
+penA	1719	
+penA	1720	
+penA	1721	
+penA	1722	
+penA	1723	
+penA	1724	
+penA	1725	
+penA	1726	
+penA	1727	
+penA	1728	
+penA	1729	
+penA	1730	
+penA	1731	
+penA	1732	
+penA	1733	
+penA	1734	
+penA	1735	
+penA	1736	
+penA	1737	
+penA	1738	
+penA	1739	
+penA	1740	
+penA	1741	
+penA	1742	
+penA	1743	
+penA	1744	
+penA	1745	
+penA	1746	
+penA	1747	
+penA	1748	
+penA	1749	
+penA	1750	
+penA	1751	
+penA	1752	
+penA	1753	
+penA	1754	
+penA	1755	
+penA	1756	
+penA	1757	
+penA	1758	
+penA	1759	
+penA	1760	
+penA	1761	
+penA	1762	
+penA	1763	
+penA	1764	
+penA	1765	
+penA	1766	
+penA	1767	
+penA	1768	
+penA	1769	
+penA	1770	
+penA	1771	
+penA	1772	
+penA	1773	
+penA	1774	
+penA	1775	
+penA	1776	
+penA	1777	
+penA	1778	penA Type XIV NonMosaic NG STAR penA allele: 14.005
+penA	1779	penA Type XIV NonMosaic NG STAR penA allele: 14.006
+penA	1780	penA Type 92 Mosaic NG STAR penA allele: 92.001
+penA	1781	
+penA	1782	
+penA	1783	
+penA	1784	
+penA	1785	
+penA	1786	
+penA	1787	
+penA	1788	
+penA	1789	
+penA	1790	
+penA	1791	
+penA	1792	
+penA	1793	
+penA	1794	
+penA	1795	
+penA	1796	
+penA	1797	
+penA	1798	
+penA	1799	
+penA	1800	
+penA	1801	
+penA	1802	
+penA	1803	
+penA	1804	
+penA	1805	
+penA	1806	
+penA	1807	
+penA	1808	
+penA	1809	
+penA	1810	
+penA	1811	
+penA	1812	
+penA	1813	
+penA	1814	
+penA	1815	
+penA	1816	
+penA	1817	
+penA	1818	
+penA	1819	
+penA	1820	penA Type 106 NonMosaic NG STAR penA allele: 106.001
+penA	1821	penA Type 149 Mosaic; A501V NG STAR penA allele: 149.001
+penA	1822	penA Type 150 SemiMosaic; A517G G543S NG STAR penA allele: 150.001
+penA	1823	
+penA	1824	Type 151 Non Mosaic; A517G; NG STAR penA allele: 151.001
+penA	1825	
+penA	1826	
+penA	1827	
+penA	1828	
+penA	1829	
+penA	1830	
+penA	1831	
+penA	1832	penA Type X Mosaic;  Mutations: N513Y NG STAR penA allele: 10.008
+penA	1833	penA Type 152 Mosaic;  mutations: N513Y NG STAR penA allele: 152.001
+penA	1834	mutations present: I312→M YES; V316→T YES; D345→a YES; F504→L YES; N512→Y NO; G545→S NO penA Type 101 Mosaic; A501→V;  NG STAR penA allele: 101.001
+penA	1835	mutations present: I312→M NO; V316→T NO; D345→a NO; F504→L YES; N512→Y NO; G545→S NO penA Type: 2; Non-Mosaic NG STAR penA allele: 2.033
+penA	1836	penA Type XXXIV Mosaic NG STAR penA allele: 34.015
+penA	1837	
+penA	1838	
+penA	1839	
+penA	1840	
+penA	1841	
+penA	1842	
+penA	1843	
+penA	1844	
+penA	1845	
+penA	1846	
+penA	1847	
+penA	1848	
+penA	1849	
+penA	1850	
+penA	1851	
+penA	1852	
+penA	1853	
+penA	1854	
+penA	1855	
+penA	1856	
+penA	1857	
+penA	1858	
+penA	1859	
+penA	1860	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.039
+penA	1861	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.040
+penA	1862	
+penA	1863	
+penA	1864	
+penA	1865	
+penA	1866	
+penA	1867	
+penA	1868	
+penA	1869	
+penA	1870	
+penA	1871	
+penA	1872	
+penA	1873	Type 153 Non Mosaic; A517G; NG STAR penA allele: 153.001
+penA	1874	penA Type II NonMosaic;  A517G Ng STAR allele: 2.041
+penA	1875	
+penA	1876	
+penA	1877	
+penA	1878	
+penA	1879	
+penA	1880	
+penA	1881	
+penA	1882	
+penA	1883	
+penA	1884	
+penA	1885	
+penA	1886	
+penA	1887	
+penA	1888	
+penA	1889	
+penA	1890	
+penA	1891	
+penA	1892	
+penA	1893	
+penA	1894	
+penA	1895	
+penA	1896	
+penA	1897	
+penA	1898	
+penA	1899	
+penA	1900	
+penA	1901	penA Type: 43; Non-Mosaic; NG STAR penA allele: 43.004
+penA	1902	Type V Non-Mosaic NG STAR penA allele: 5.009
+penA	1903	Type X mosaic NG STAR penA allele: 10.003 N513Y
+penA	1904	penA Type XI Non Mosaic; NG STAR penA allele: 11.002
+penA	1905	Type XVIII non mosaic NG STAR penA allele: 18.004, A501T A517G G543S
+penA	1906	Type XXI non-mosaic NG STAR penA allele: 21.004
+penA	1907	Type 154 Non Mosaic; A501V A517G; NG STAR penA allele: 154.001
+penA	1908	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.042
+penA	1909	penA Type: 103; Non-Mosaic; NG STAR penA allele: 103.001
+penA	1910	Type XII non-mosaic NG STAR penA allele: 12.010
+penA	1911	Type 155 Non Mosaic; A501V A517G; NG STAR penA allele: 155.001
+penA	1912	penA Type: 86; Non-Mosaic; NG STAR penA allele: 86.001
+penA	1913	
+penA	1914	Type 157 Non Mosaic; A517G; NG STAR penA allele: 157.001
+penA	1915	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.043
+penA	1916	Type 158 Non Mosaic; A501V, A517G; NG STAR penA allele: 158.001
+penA	1917	Type XLIV non-mosaic NG STAR penA allele: 44.007
+penA	1918	Type XIV non-mosaic NG STAR penA allele: 14.013; A517G
+penA	1919	Type 159 Non Mosaic; A517G; NG STAR penA allele: 159.001
+penA	1920	Type 160 Non Mosaic; A517G; NG STAR penA allele: 160.001
+penA	1921	penA Type IX Non Mosaic; NG STAR penA allele: 9.007; A517G
+penA	1922	Type 69 Non Mosaic; A517G; NG STAR penA allele 69.004
+penA	1923	
+penA	1924	
+penA	1925	penA Type 176 NonMosaic NG STAR penA allele: 176.001
+penA	1926	
+penA	1927	penA Type: 2; Non-Mosaic; NG STAR penA allele: 2.017
+penA	1928	penA Type: 1; Non-Mosaic; NG STAR penA allele: 1.008
+penA	1929	penA Type: 22; Non-Mosaic; NG STAR penA allele: 22.012
+penA	1930	penA Type: 22; Non-Mosaic; NG STAR penA allele: 22.011
+penA	1931	penA Type: 2; Non-Mosaic; NG STAR penA allele: 2.015
+penA	1932	penA Type: 34; Mosaic; NG STAR penA allele: 34.013
+penA	1933	penA Type: 69; Non-Mosaic; NG STAR penA allele: 69.003
+penA	1934	penA Type: 90; Non-Mosaic; NG STAR penA allele: 90.001
+penA	1935	penA Type: 2; Non-Mosaic; NG STAR penA allele: 2.018
+penA	1936	penA Type: 12; Non-Mosaic; NG STAR penA allele: 12.007
+penA	1937	penA Type: 19; Non-Mosaic; NG STAR penA allele: 19.002
+penA	1938	penA Type: 44; Non-Mosaic; NG STAR penA allele: 44.003
+penA	1939	Type 161 Non Mosaic; A517G; NG STAR penA allele: 161.001
+penA	1940	
+penA	1941	
+penA	1942	
+penA	1943	
+penA	1944	
+penA	1945	
+penA	1946	
+penA	1947	
+penA	1948	
+penA	1949	
+penA	1950	
+penA	1951	
+penA	1952	
+penA	1953	
+penA	1954	
+penA	1955	
+penA	1956	
+penA	1957	
+penA	1958	
+penA	1959	
+penA	1960	
+penA	1961	
+penA	1962	
+penA	1963	
+penA	1964	
+penA	1965	
+penA	1966	
+penA	1967	
+penA	1968	
+penA	1969	
+penA	1970	
+penA	1971	
+penA	1972	
+penA	1973	
+penA	1974	
+penA	1975	
+penA	1976	
+penA	1977	
+penA	1978	
+penA	1979	
+penA	1980	
+penA	1981	
+penA	1982	
+penA	1983	
+penA	1984	
+penA	1985	
+penA	1986	
+penA	1987	
+penA	1988	
+penA	1989	
+penA	1990	
+penA	1991	
+penA	1992	
+penA	1993	
+penA	1994	
+penA	1995	
+penA	1996	
+penA	1997	
+penA	1998	
+penA	1999	
+penA	2000	
+penA	2001	
+penA	2002	
+penA	2003	
+penA	2004	
+penA	2005	
+penA	2006	
+penA	2007	
+penA	2008	
+penA	2009	
+penA	2010	
+penA	2011	
+penA	2012	
+penA	2013	
+penA	2014	
+penA	2015	
+penA	2016	
+penA	2017	
+penA	2018	
+penA	2019	
+penA	2020	
+penA	2021	
+penA	2022	
+penA	2023	
+penA	2024	
+penA	2025	
+penA	2026	
+penA	2027	
+penA	2028	
+penA	2029	
+penA	2030	
+penA	2031	
+penA	2032	
+penA	2033	
+penA	2034	
+penA	2035	
+penA	2036	
+penA	2037	
+penA	2038	
+penA	2039	
+penA	2040	
+penA	2041	
+penA	2042	
+penA	2043	
+penA	2044	
+penA	2045	
+penA	2046	
+penA	2047	
+penA	2048	
+penA	2049	
+penA	2050	
+penA	2051	
+penA	2052	
+penA	2053	
+penA	2054	
+penA	2055	
+penA	2056	
+penA	2057	
+penA	2058	
+penA	2059	
+penA	2060	
+penA	2061	
+penA	2062	
+penA	2063	
+penA	2064	
+penA	2065	
+penA	2066	
+penA	2067	
+penA	2068	
+penA	2069	
+penA	2070	
+penA	2071	
+penA	2072	
+penA	2073	
+penA	2074	
+penA	2075	
+penA	2076	
+penA	2077	
+penA	2078	
+penA	2079	
+penA	2080	
+penA	2081	
+penA	2082	
+penA	2083	
+penA	2084	
+penA	2085	
+penA	2086	
+penA	2087	
+penA	2088	
+penA	2089	
+penA	2090	
+penA	2091	
+penA	2092	
+penA	2093	
+penA	2094	
+penA	2095	
+penA	2096	
+penA	2097	
+penA	2098	
+penA	2099	
+penA	2100	
+penA	2101	
+penA	2102	
+penA	2103	
+penA	2104	
+penA	2105	
+penA	2106	
+penA	2107	
+penA	2108	
+penA	2109	
+penA	2110	
+penA	2111	
+penA	2112	
+penA	2113	
+penA	2114	
+penA	2115	
+penA	2116	
+penA	2117	
+penA	2118	
+penA	2119	
+penA	2120	
+penA	2121	Type 162 Non Mosaic; A517G; NG STAR penA allele: 162.001
+penA	2122	
+penA	2123	
+penA	2124	
+penA	2125	
+penA	2126	
+penA	2127	
+penA	2128	
+penA	2129	
+penA	2130	
+penA	2131	
+penA	2132	
+penA	2133	
+penA	2134	
+penA	2135	
+penA	2136	
+penA	2137	
+penA	2138	
+penA	2139	
+penA	2140	
+penA	2141	
+penA	2142	
+penA	2143	
+penA	2144	
+penA	2145	
+penA	2146	
+penA	2147	
+penA	2148	
+penA	2149	
+penA	2150	
+penA	2151	
+penA	2152	
+penA	2153	
+penA	2154	
+penA	2155	
+penA	2156	
+penA	2157	
+penA	2158	
+penA	2159	
+penA	2160	
+penA	2161	
+penA	2162	
+penA	2163	
+penA	2164	
+penA	2165	
+penA	2166	
+penA	2167	
+penA	2168	
+penA	2169	
+penA	2170	
+penA	2171	
+penA	2172	Type 163 Non Mosaic; A517G, G543S; NG STAR penA allele: 163.001
+penA	2173	
+penA	2174	
+penA	2175	
+penA	2176	
+penA	2177	
+penA	2178	
+penA	2179	
+penA	2180	
+penA	2181	
+penA	2182	
+penA	2183	
+penA	2184	
+penA	2185	
+penA	2186	
+penA	2187	
+penA	2188	
+penA	2189	
+penA	2190	
+penA	2191	
+penA	2192	
+penA	2193	
+penA	2194	
+penA	2195	
+penA	2196	
+penA	2197	
+penA	2198	
+penA	2199	
+penA	2200	
+penA	2201	
+penA	2202	
+penA	2203	
+penA	2204	
+penA	2205	
+penA	2206	
+penA	2207	
+penA	2208	
+penA	2209	
+penA	2210	
+penA	2211	
+penA	2212	
+penA	2213	
+penA	2214	
+penA	2215	
+penA	2216	
+penA	2217	
+penA	2218	
+penA	2219	
+penA	2220	
+penA	2221	
+penA	2222	
+penA	2223	
+penA	2224	
+penA	2225	
+penA	2226	
+penA	2227	
+penA	2228	
+penA	2229	
+penA	2230	
+penA	2231	
+penA	2232	
+penA	2233	
+penA	2234	
+penA	2235	
+penA	2236	
+penA	2237	
+penA	2238	
+penA	2239	
+penA	2240	
+penA	2241	
+penA	2242	
+penA	2243	
+penA	2244	
+penA	2245	Type 164 Semi Mosaic; N513Y; NG STAR penA allele: 164.001
+penA	2246	penA Type: 2; Non-Mosaic; NG STAR penA allele: 2.022
+penA	2247	Type 165 Semi Mosaic; N513Y; NG STAR penA allele: 165.001
+penA	2248	penA Type: 89 Semi-Mosaic; NG STAR penA allele: 89.001
+penA	2249	Type 166 Mosaic; N513Y; NG STAR penA allele: 166.001
+penA	2250	Type 167 Semi Mosaic; N513Y; NG STAR penA allele: 167.001
+penA	2251	
+penA	2252	
+penA	2253	
+penA	2254	
+penA	2255	
+penA	2256	
+penA	2257	
+penA	2258	
+penA	2259	
+penA	2260	
+penA	2261	
+penA	2262	
+penA	2263	
+penA	2264	
+penA	2265	
+penA	2266	
+penA	2267	
+penA	2268	
+penA	2269	
+penA	2270	
+penA	2271	
+penA	2272	
+penA	2273	
+penA	2274	
+penA	2275	
+penA	2276	
+penA	2277	
+penA	2278	Type 103 Non Mosaic; A501V A517G; NG STAR penA allele: 103.004
+penA	2279	
+penA	2280	
+penA	2281	
+penA	2282	
+penA	2283	
+penA	2284	
+penA	2285	
+penA	2286	
+penA	2287	
+penA	2288	
+penA	2289	
+penA	2290	
+penA	2291	
+penA	2292	
+penA	2293	
+penA	2294	
+penA	2295	
+penA	2296	
+penA	2297	
+penA	2298	
+penA	2299	
+penA	2300	
+penA	2301	
+penA	2302	
+penA	2303	
+penA	2304	
+penA	2305	
+penA	2306	
+penA	2307	
+penA	2308	
+penA	2309	
+penA	2310	
+penA	2311	
+penA	2312	
+penA	2313	
+penA	2314	
+penA	2315	
+penA	2316	
+penA	2317	
+penA	2318	
+penA	2319	
+penA	2320	
+penA	2321	
+penA	2322	
+penA	2323	
+penA	2324	
+penA	2325	
+penA	2326	
+penA	2327	
+penA	2328	
+penA	2329	
+penA	2330	
+penA	2331	
+penA	2332	
+penA	2333	
+penA	2334	
+penA	2335	
+penA	2336	
+penA	2337	
+penA	2338	
+penA	2339	
+penA	2340	
+penA	2341	
+penA	2342	
+penA	2343	
+penA	2344	
+penA	2345	
+penA	2346	
+penA	2347	
+penA	2348	
+penA	2349	
+penA	2350	
+penA	2351	
+penA	2352	
+penA	2353	
+penA	2354	
+penA	2355	
+penA	2356	
+penA	2357	
+penA	2358	
+penA	2359	
+penA	2360	
+penA	2361	penA Type XXII NonMosaic; A517G NG STAR penA allele: 22.014
+penA	2362	penA Type XIV NonMosaic; A517G NG STAR penA allele: 14.014
+penA	2363	
+penA	2364	I312→M NO; V316→T NO; D345→a NO; A501→T YES; F504→L YES; N512→Y NO; G545→S NO; P551→S/L YES Type XLIV non-mosaic
+penA	2365	mutations present: F504→L Type II Non-mosaic
+penA	2366	penA Type 109 NonMosaic; A501V, A517G NG STAR penA allele: 109.001
+penA	2367	Type II NonMosaic A517G
+penA	2368	mutations present: F504→L Type II non-mosaic
+penA	2369	penA Type 95 NonMosaic NG STAR allele 95.001
+penA	2370	penA Type 96 NonMosaic NG STAR 96.001
+penA	2371	NG STAR allele 97.001  NonMosaic
+penA	2372	Type 98 Non Mosaic; NG STAR penA allele: 98.001
+penA	2373	Type XV non-mosaic NG STAR penA allele: 15.005
+penA	2374	Wild Type Non Mosaic; NG STAR penA allele 100.009
+penA	2375	Wild Type Non Mosaic; NG STAR penA allele: 100.011
+penA	2376	Wild Type Non Mosaic; NG STAR penA allele: 100.012
+penA	2377	penA Type: 1; Non-Mosaic; NG STAR penA allele: 1.009
+penA	2378	Wild type non-mosaic; NG STAR penA allele: 100.013
+penA	2379	Type 99 Non Mosaic; A311V; NG STAR penA allele: 99.001
+penA	2380	Type XIX non-mosaic NG STAR penA allele: 19.004, A517G
+penA	2381	Wild Type Non Mosaic; NG STAR penA allele: 100.015
+penA	2382	Wild type; non-mosaic; NG STAR penA allele: 100.014
+penA	2383	Type 98 Non Mosaic; NG STAR penA allele: 98.002
+penA	2384	Type XV non-mosaic NG STAR penA allele: 15.006
+penA	2385	Type XXI non-mosaic NG STAR penA allele: 21.002
+penA	2386	Type 104 Non Mosaic; A501T, A517G, G543S; NG STAR penA allele: 104.001
+penA	2387	Type X mosaic NG STAR penA allele: 10.009 N513Y
+penA	2388	penA Type: 1; Non-Mosaic; NG STAR penA allele: 1.013
+penA	2389	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.048
+penA	2390	
+penA	2391	penA Type V Nonmosaic; A517G, G543S
+penA	2392	Type 230 Non Mosaic; NG STAR penA allele: 230.001
+penA	2393	penA Type II NonMosaic; A517G NG STAR penA allele 2.023
+penA	2394	Type XIV non-mosaic NG STAR penA allele: 14.018; A517G
+penA	2395	Type 192 Non Mosaic; A517G; NG STAR penA allele: 192.001
+penA	2396	Type 193 Non Mosaic; A517G; NG STAR penA allele: 193.001
+penA	2397	Type 194 Non Mosaic; A517G; NG STAR penA allele: 194.001
+penA	2398	Type XIV non-mosaic NG STAR penA allele: 14.019; A517G
+penA	2399	Type XIV non-mosaic NG STAR penA allele: 14.017; A517G
+penA	2400	Type 190 Non Mosaic; A517G; NG STAR penA allele: 190.001
+penA	2401	Type 191 Non Mosaic; A517G; NG STAR penA allele: 191.001
+penA	2402	penA Type IX Non Mosaic; NG STAR penA allele: 9.010
+penA	2403	
+penA	2404	
+penA	2405	penA Type I Non Mosaic; NG STAR penA allele: 1.022
+penA	2406	Type V Non Mosaic; A517G, G543S NG STAR penA allele: 5.020
+penA	2407	
+penA	2408	
+penA	2409	
+penA	2410	
+penA	2411	
+penA	2412	
+penA	2413	
+penA	2414	
+penA	2415	
+penA	2416	
+penA	2417	
+penA	2418	
+penA	2419	
+penA	2420	
+penA	2421	
+penA	2422	
+penA	2423	
+penA	2424	
+penA	2425	
+penA	2426	
+penA	2427	
+penA	2428	
+penA	2429	
+penA	2430	
+penA	2431	
+penA	2432	
+penA	2433	
+penA	2434	
+penA	2435	
+penA	2436	
+penA	2437	
+penA	2438	
+penA	2439	
+penA	2440	
+penA	2441	
+penA	2442	
+penA	2443	
+penA	2444	
+penA	2445	
+penA	2446	
+penA	2447	
+penA	2448	
+penA	2449	
+penA	2450	
+penA	2451	
+penA	2452	
+penA	2453	
+penA	2454	
+penA	2455	
+penA	2456	
+penA	2457	
+penA	2458	
+penA	2459	
+penA	2460	
+penA	2461	
+penA	2462	
+penA	2463	
+penA	2464	
+penA	2465	
+penA	2466	
+penA	2467	
+penA	2468	
+penA	2469	
+penA	2470	
+penA	2471	
+penA	2472	
+penA	2473	
+penA	2474	
+penA	2475	
+penA	2476	
+penA	2477	
+penA	2478	
+penA	2479	
+penA	2480	
+penA	2481	
+penA	2482	
+penA	2483	
+penA	2484	
+penA	2485	
+penA	2486	
+penA	2487	
+penA	2488	
+penA	2489	
+penA	2490	
+penA	2491	
+penA	2492	
+penA	2493	
+penA	2494	
+penA	2495	
+penA	2496	
+penA	2497	
+penA	2498	
+penA	2499	
+penA	2500	
+penA	2501	
+penA	2502	
+penA	2503	
+penA	2504	
+penA	2505	
+penA	2506	
+penA	2507	
+penA	2508	
+penA	2509	
+penA	2510	
+penA	2511	
+penA	2512	
+penA	2513	
+penA	2514	
+penA	2515	
+penA	2516	
+penA	2517	
+penA	2518	
+penA	2519	
+penA	2520	
+penA	2521	
+penA	2522	
+penA	2523	
+penA	2524	
+penA	2525	
+penA	2526	
+penA	2527	
+penA	2528	Type 170 Non Mosaic; NG STAR penA allele: 170.002
+penA	2529	Type XIX non-mosaic NG STAR penA allele: 19.017
+penA	2530	
+penA	2531	
+penA	2532	Type 203 Non Mosaic; A517G; NG STAR penA allele: 203.001
+penA	2533	Type 198 Mosaic; N513Y; NG STAR penA allele: 198.001
+penA	2534	
+penA	2535	
+penA	2536	
+penA	2537	
+penA	2538	Type XIII non-mosaic NG STAR penA allele: 13.010; A501V, A517G
+penA	2539	
+penA	2540	
+penA	2541	
+penA	2542	
+penA	2543	
+penA	2544	
+penA	2545	Type X Mosaic; N513Y; NG STAR penA allele: 10.013
+penA	2546	
+penA	2547	
+penA	2548	
+penA	2549	
+penA	2550	
+penA	2551	
+penA	2552	
+penA	2553	
+penA	2554	
+penA	2555	
+penA	2556	Type 112 Semi Mosaic; N513Y; NG STAR penA allele: 112.001
+penA	2557	Type XVI non-mosaic NG STAR penA allele: 16.001, A517G
+penA	2558	Type 180 Mosaic; N513Y; NG STAR penA allele: 180.001
+penA	2559	Type XIX non-mosaic NG STAR penA allele: 19.005
+penA	2560	penA Type III NonMosaic NG STAR penA allele: 3.002
+penA	2561	Type 113 Semi Mosaic; N513Y; NG STAR penA allele: 113.001
+penA	2562	
+penA	2563	Type XIX non-mosaic NG STAR penA allele: 19.014
+penA	2564	
+penA	2565	
+penA	2566	
+penA	2567	
+penA	2568	Type XLV non-mosaic NG STAR penA allele: 45.003
+penA	2569	Type 76 Non Mosaic; NG STAR penA allele: 76.002
+penA	2570	Type 199 Non Mosaic; A517G; NG STAR penA allele: 199.001
+penA	2571	
+penA	2572	
+penA	2573	
+penA	2574	
+penA	2575	Type 187 Non Mosaic; NG STAR penA allele: 187.001
+penA	2576	
+penA	2577	penA Type IX Non Mosaic; NG STAR penA allele: 9.009; A517G
+penA	2578	
+penA	2579	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.054
+penA	2580	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.047
+penA	2581	
+penA	2582	
+penA	2583	
+penA	2584	
+penA	2585	
+penA	2586	Type XLIII non-mosaic NG STAR penA allele: 43.006
+penA	2587	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.053
+penA	2588	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.055
+penA	2589	penA Type III NonMosaic NG STAR penA allele: 3.003; A517G
+penA	2590	penA Type IX Non Mosaic; NG STAR penA allele: 9.008; A517G
+penA	2591	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.052
+penA	2592	
+penA	2593	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.044
+penA	2594	
+penA	2595	
+penA	2596	
+penA	2597	
+penA	2598	
+penA	2599	
+penA	2600	
+penA	2601	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.056
+penA	2602	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.046
+penA	2603	penA Type IX Non Mosaic; NG STAR penA allele: 9.011
+penA	2604	
+penA	2605	
+penA	2606	
+penA	2607	
+penA	2608	Type XXXIV mosaic NG STAR penA allele: 34.025
+penA	2609	
+penA	2610	
+penA	2611	
+penA	2612	
+penA	2613	
+penA	2614	
+penA	2615	
+penA	2616	
+penA	2617	
+penA	2618	penA Type II NonMosaic; A517G, NG STAR penA allele: 2.051
+penA	2619	Type 43 Non Mosaic; A501V, A517G; NG STAR penA allele 43.008
+penA	2620	
+penA	2621	
+penA	2622	
+penA	2623	
+penA	2624	
+penA	2625	
+penA	2626	
+penA	2627	
+penA	2628	Type 102 Non Mosaic; A517G; NG STAR penA allele: 102.001
+penA	2629	
+penA	2630	
+penA	2631	
+penA	2632	
+penA	2633	
+penA	2634	
+penA	2635	
+penA	2636	penA Type: 1; Non-Mosaic; NG STAR penA allele: 1.011
+penA	2637	Type 123 Non Mosaic; NG STAR penA allele: 123.001
+penA	2638	Type XIX non-mosaic NG STAR penA allele: 19.006
+penA	2639	
+penA	2640	
+penA	2641	
+penA	2642	
+penA	2643	
+penA	2644	
+penA	2645	
+penA	2646	Type XIV non-mosaic NG STAR penA allele: 14.009; A517G
+penA	2647	Type 67 Mosaic; N513Y; NG STAR penA allele: 67.002
+penA	2648	Type II Non-mosaic NG STAR penA allele: 2.031
+penA	2649	Type II Non-mosaic NG STAR penA allele: 2.030; A517G
+penA	2650	Type 137 Non Mosaic; A517G, G543S; NG STAR penA allele: 137.001
+penA	2651	Type 138 Mosaic; N513Y; NG STAR penA allele: 138.001
+penA	2652	Type XXXIV mosaic NG STAR penA allele: 34.018
+penA	2653	penA Type 139 Mosaic; Wild Type; NG STAR penA allele: 139.001
+penA	2654	Type 140 Semi Mosaic; A517G; NG STAR penA allele: 140.001
+penA	2655	Type 132 Non Mosaic; A517G; NG STAR penA allele: 132.001
+penA	2656	
+penA	2657	
+penA	2658	Type XXVII Mosaic NG STAR penA allele: 27.003, N513Y
+penA	2659	
+penA	2660	
+penA	2661	
+penA	2662	
+penA	2663	
+penA	2664	
+penA	2665	
+penA	2666	
+penA	2667	
+penA	2668	
+penA	2669	
+penA	2670	
+penA	2671	
+penA	2672	
+penA	2673	
+penA	2674	Type V Non-Mosaic NG STAR penA allele: 5.011
+penA	2675	
+penA	2676	
+penA	2677	
+penA	2678	
+penA	2679	
+penA	2680	
+penA	2681	
+penA	2682	
+penA	2683	
+penA	2684	
+penA	2685	
+penA	2686	
+penA	2687	
+penA	2688	
+penA	2689	
+penA	2690	
+penA	2691	
+penA	2692	
+penA	2693	
+penA	2694	
+penA	2695	
+penA	2696	
+penA	2697	
+penA	2698	
+penA	2699	
+penA	2700	
+penA	2701	
+penA	2702	
+penA	2703	
+penA	2704	
+penA	2705	
+penA	2706	
+penA	2707	
+penA	2708	
+penA	2709	
+penA	2710	
+penA	2711	
+penA	2712	
+penA	2713	
+penA	2714	
+penA	2715	
+penA	2716	
+penA	2717	
+penA	2718	
+penA	2719	
+penA	2720	
+penA	2721	
+penA	2722	
+penA	2723	
+penA	2724	
+penA	2725	
+penA	2726	
+penA	2727	
+penA	2728	
+penA	2729	
+penA	2730	
+penA	2731	
+penA	2732	
+penA	2733	
+penA	2734	
+penA	2735	
+penA	2736	
+penA	2737	
+penA	2738	
+penA	2739	
+penA	2740	
+penA	2741	
+penA	2742	
+penA	2743	
+penA	2744	
+penA	2745	
+penA	2746	
+penA	2747	
+penA	2748	
+penA	2749	
+penA	2750	
+penA	2751	
+penA	2752	
+penA	2753	
+penA	2754	
+penA	2755	
+penA	2756	
+penA	2757	
+penA	2758	
+penA	2759	
+penA	2760	
+penA	2761	
+penA	2762	
+penA	2763	
+penA	2764	
+penA	2765	
+penA	2766	
+penA	2767	
+penA	2768	
+penA	2769	
+penA	2770	
+penA	2771	
+penA	2772	
+penA	2773	
+penA	2774	
+penA	2775	
+penA	2776	
+penA	2777	
+penA	2778	
+penA	2779	
+penA	2780	
+penA	2781	
+penA	2782	
+penA	2783	
+penA	2784	
+penA	2785	
+penA	2786	
+penA	2787	
+penA	2788	
+penA	2789	
+penA	2790	
+penA	2791	
+penA	2792	
+penA	2793	
+penA	2794	
+penA	2795	
+penA	2796	
+penA	2797	
+penA	2798	
+penA	2799	
+penA	2800	
+penA	2801	
+penA	2802	
+penA	2803	
+penA	2804	
+penA	2805	
+penA	2806	
+penA	2807	
+penA	2808	
+penA	2809	
+penA	2810	
+penA	2811	
+penA	2812	
+penA	2813	
+penA	2814	
+penA	2815	
+penA	2816	
+penA	2817	
+penA	2818	
+penA	2819	
+penA	2820	
+penA	2821	
+penA	2822	
+penA	2823	
+penA	2824	
+penA	2825	
+penA	2826	
+penA	2827	
+penA	2828	
+penA	2829	
+penA	2830	
+penA	2831	
+penA	2832	
+penA	2833	
+penA	2834	
+penA	2835	
+penA	2836	
+penA	2837	Type 232 Mosaic; A311V, N513Y; NG STAR penA allele: 232.001
+penA	2838	
+penA	2839	Type 213 Non Mosaic; A501P, A517G; NG STAR penA allele: 213.001
+penA	2840	
+penA	2841	
+penA	2842	
+penA	2843	Type X Mosaic NG STAR penA allele: 10.004; N513Y
+penA	2844	Type V Non Mosaic; A517G, G543S NG STAR penA allele: 5.014
+penA	2845	
+penA	2846	Type XXXIV mosaic NG STAR penA allele: 34.019
+penA	2847	
+penA	2848	Type XXXIV mosaic NG STAR penA allele: 34.030
+penA	2849	Type XIII Non Mosaic; A501V; A517G; NG STAR penA allele: 13.003
+penA	2850	
+penA	2851	
+penA	2852	
+penA	2853	
+penA	2854	
+penA	2855	
+penA	2856	
+penA	2857	
+penA	2858	
+penA	2859	
+penA	2860	
+penA	2861	
+penA	2862	
+penA	2863	
+penA	2864	
+penA	2865	
+penA	2866	
+penA	2867	
+penA	2868	
+penA	2869	
+penA	2870	
+penA	2871	
+penA	2872	
+penA	2873	
+penA	2874	
+penA	2875	
+penA	2876	
+penA	2877	
+penA	2878	
+penA	2879	
+penA	2880	
+penA	2881	
+penA	2882	
+penA	2883	
+penA	2884	
+penA	2885	
+penA	2886	
+penA	2887	
+penA	2888	
+penA	2889	
+penA	2890	
+penA	2891	
+penA	2892	
+penA	2893	
+penA	2894	
+penA	2895	
+penA	2896	
+penA	2897	
+penA	2898	
+penA	2899	
+penA	2900	
+penA	2901	
+penA	2902	
+penA	2903	
+penA	2904	
+penA	2905	
+penA	2906	
+penA	2907	
+penA	2908	
+penA	2909	
+penA	2910	
+penA	2911	
+penA	2912	
+penA	2913	
+penA	2914	
+penA	2915	
+penA	2916	
+penA	2917	
+penA	2918	
+penA	2919	
+penA	2920	
+penA	2921	
+penA	2922	
+penA	2923	
+penA	2924	
+penA	2925	
+penA	2926	
+penA	2927	
+penA	2928	
+penA	2929	
+penA	2930	
+penA	2931	
+penA	2932	
+penA	2933	
+penA	2934	
+penA	2935	
+penA	2936	
+penA	2937	
+penA	2938	
+penA	2939	
+penA	2940	
+penA	2941	
+penA	2942	
+penA	2943	
+penA	2944	
+penA	2945	
+penA	2946	
+penA	2947	
+penA	2948	
+penA	2949	
+penA	2950	
+penA	2951	
+penA	2952	
+penA	2953	
+penA	2954	
+penA	2955	
+penA	2956	
+penA	2957	
+penA	2958	
+penA	2959	
+penA	2960	
+penA	2961	
+penA	2962	
+penA	2963	
+penA	2964	
+penA	2965	
+penA	2966	
+penA	2967	
+penA	2968	
+penA	2969	
+penA	2970	
+penA	2971	
+penA	2972	
+penA	2973	
+penA	2974	
+penA	2975	
+penA	2976	
+penA	2977	
+penA	2978	
+penA	2979	
+penA	2980	
+penA	2981	
+penA	2982	
+penA	2983	
+penA	2984	
+penA	2985	
+penA	2986	
+penA	2987	
+penA	2988	
+penA	2989	
+penA	2990	
+penA	2991	
+penA	2992	
+penA	2993	Type 179 Non Mosaic; NG STAR penA allele: 179.001
+penA	2994	mutations present: F504→L; A517→G  Type II non-mosaic NG STAR penA allele: 2.064
+penA	2995	mutations present: F504→L; A517→G Type II non-mosaic NG STAR penA allele: 2.065
+penA	2996	
+penA	2997	
+penA	2998	Type 184 NonMosaic; NG STAR penA allele: 184.001
+penA	2999	Type 227 Non Mosaic; A517G, G543S; NG STAR penA allele: 227.001
+penA	3000	Type 220 Non Mosaic; NG STAR penA allele: 220.001
+penA	3001	
+penA	3002	
+penA	3003	Type 228 Non Mosaic; A517G; NG STAR penA allele: 228.001
+penA	3004	penA Type II Non Mosaic; A517G; NG STAR penA allele: 2.061
+penA	3005	
+penA	3006	Type XIV non-mosaic NG STAR penA allele: 14.023; A517G
+penA	3007	
+penA	3008	
+penA	3009	
+penA	3010	
+penA	3011	
+penA	3012	
+mtrR	1	-35A Del Azithromycin: 0.25 Spectinomycin: 16 Tetracycline: 32
+mtrR	2	-35A Del Azithromycin: 0.5 Spectinomycin: 16
+mtrR	3	Wild-Type
+mtrR	4	Wild-Type
+mtrR	5	Wild-type
+mtrR	6	Wild-Type
+mtrR	7	Wild-Type
+mtrR	8	Wild-Type
+mtrR	9	A39T
+mtrR	10	A39T
+mtrR	11	A39T
+mtrR	12	Wild-Type
+mtrR	13	Wild-Type
+mtrR	14	Wild-Type
+mtrR	15	Wild-Type
+mtrR	16	-35A Del
+mtrR	17	Wild-Type
+mtrR	18	Wild-Type
+mtrR	19	-35A Del, G45D
+mtrR	20	A39T
+mtrR	21	Wild-Type
+mtrR	22	-35A Del
+mtrR	23	A39T
+mtrR	24	A39T
+mtrR	25	G45D
+mtrR	26	A39T
+mtrR	27	N. meningitidis-like promoter
+mtrR	28	N. meningitidis-like promoter
+mtrR	29	Wild-Type
+mtrR	30	N. meningitidis-like promoter
+mtrR	31	A39T
+mtrR	32	Wild-Type
+mtrR	33	Wild-Type
+mtrR	34	-35A Del
+mtrR	35	A39T
+mtrR	36	-35A Del, A39T
+mtrR	37	-35A Del, A39T, G45D
+mtrR	38	A39T
+mtrR	39	N. meningitidis-like promoter
+mtrR	40	A39T
+mtrR	41	A39T
+mtrR	42	A39T
+mtrR	43	A39T
+mtrR	44	N. meningitidis-like promoter
+mtrR	45	Wild-Type
+mtrR	46	N. meningitidis-like promoter
+mtrR	47	A39T
+mtrR	48	Wild-Type
+mtrR	49	A39T
+mtrR	50	Wild-Type
+mtrR	51	Wild-Type
+mtrR	52	Wild-type
+mtrR	53	A39T, G45D
+mtrR	54	A39T
+mtrR	55	Wild-type
+mtrR	56	N. meningitidis-like promoter
+mtrR	57	Wild-type
+mtrR	58	Wild-type
+mtrR	59	A39T
+mtrR	60	Wild-type
+mtrR	61	A39T
+mtrR	62	A39T
+mtrR	63	35A Del, A39T
+mtrR	64	-35A Del
+mtrR	65	A39T
+mtrR	66	A39T; T insert bp19
+mtrR	67	Wild-type
+mtrR	68	A39T
+mtrR	69	Wild-type
+mtrR	70	-35Adel,G45D
+mtrR	71	A39T
+mtrR	72	Wild-type; CC637ins
+mtrR	73	A39T
+mtrR	74	Wild-type
+mtrR	75	Wild-type
+mtrR	76	A39T
+mtrR	77	A39T
+mtrR	78	A39T
+mtrR	79	-35Adel
+mtrR	80	Wild-type
+mtrR	81	Wild-type
+mtrR	82	A39T
+mtrR	83	A39T
+mtrR	84	A39T
+mtrR	85	A39T
+mtrR	86	Wild-type
+mtrR	87	A39T
+mtrR	88	Wild-type
+mtrR	89	A39T
+mtrR	90	Wild-type
+mtrR	91	Wild-type
+mtrR	92	A39T
+mtrR	93	A39T
+mtrR	94	Wild-type
+mtrR	95	-35A del; A39T
+mtrR	96	A39T
+mtrR	97	A39T
+mtrR	98	Wild-type
+mtrR	99	A39T
+mtrR	100	corresponds to Wild Type allele 0 in published NG STAR scheme
+mtrR	101	A39T
+mtrR	102	Wild-type
+mtrR	103	Wild-type
+mtrR	104	Wild-type
+mtrR	105	A39T, G45D
+mtrR	106	Wild-type
+mtrR	107	A39T
+mtrR	108	Wild-type
+mtrR	109	Wild-type
+mtrR	110	-35A del, A39T
+mtrR	111	-35A del
+mtrR	112	A39T
+mtrR	113	-35A del
+mtrR	114	Wild-type
+mtrR	115	A39T
+mtrR	116	A39T
+mtrR	117	Wild-type
+mtrR	118	-35A del
+mtrR	119	Wild-type
+mtrR	120	G45D
+mtrR	121	Wild-type
+mtrR	122	A39T
+mtrR	123	A39T
+mtrR	124	A39T
+mtrR	125	A39T
+mtrR	126	A39T
+mtrR	127	Wild-type
+mtrR	128	A39T
+mtrR	129	Wild-type
+mtrR	130	A39T
+mtrR	131	A39T
+mtrR	132	-35A del, G45D
+mtrR	133	A39T
+mtrR	134	Wild-type
+mtrR	135	A39T
+mtrR	136	Wild-type
+mtrR	137	Wild-type
+mtrR	138	Wild-type
+mtrR	139	Wild-type
+mtrR	140	A39T
+mtrR	141	A39T
+mtrR	142	Wild-type
+mtrR	143	Wild-type
+mtrR	144	A39T
+mtrR	145	Wild-type
+mtrR	146	Wild-type
+mtrR	147	-35A del
+mtrR	148	Wild-type
+mtrR	149	A39T
+mtrR	150	A39T
+mtrR	151	Wild-type
+mtrR	152	Wild-type
+mtrR	153	A39T
+mtrR	154	A39T
+mtrR	155	A39T
+mtrR	156	A39T
+mtrR	157	A39T
+mtrR	158	-35A del, G45D
+mtrR	159	Wild-type
+mtrR	160	Wild-type
+mtrR	161	Wild-Type
+mtrR	162	Wild-type
+mtrR	163	A39T
+mtrR	164	A39T
+mtrR	165	Disrupted WHO-P like promoter
+mtrR	166	A39T
+mtrR	167	A39T
+mtrR	168	Wild Type
+mtrR	169	Wild Type
+mtrR	170	Disrupted WHO-P like promoter
+mtrR	171	Wild Type
+mtrR	172	-35A Del
+mtrR	173	Wild Type
+mtrR	174	A39T
+mtrR	175	Wild Type
+mtrR	176	A39T
+mtrR	177	-35A Del
+mtrR	178	A39T
+mtrR	179	-35A Del, A39T
+mtrR	180	Meningiditis-like promoter
+mtrR	181	A39T
+mtrR	182	Wild-Type
+mtrR	183	A39T
+mtrR	184	Wild-Type
+mtrR	185	A39T
+mtrR	186	A39T
+mtrR	187	Wild-Type
+mtrR	188	Wild-Type
+mtrR	189	Wild-Type
+mtrR	190	A39T
+mtrR	191	-35A Del
+mtrR	192	-35A Del
+mtrR	193	Wild-Type
+mtrR	194	A39T
+mtrR	195	A39T
+mtrR	196	A39T
+mtrR	197	A39T
+mtrR	198	A39T
+mtrR	199	A39T
+mtrR	200	A39T
+mtrR	201	A39T
+mtrR	202	A39T
+mtrR	203	A39T
+mtrR	204	A39T
+mtrR	205	Wild-Type
+mtrR	206	A39T
+mtrR	207	Wild-Type
+mtrR	208	Wild-Type
+mtrR	209	Wild-Type
+mtrR	210	-35A Del
+mtrR	211	A39T
+mtrR	212	Wild-Type
+mtrR	213	Wild-Type
+mtrR	214	Wild-Type
+mtrR	215	A39T
+mtrR	216	A39T
+mtrR	217	A39T
+mtrR	218	A39T
+mtrR	219	Wild-Type
+mtrR	220	-35A Del
+mtrR	221	Wild-Type
+mtrR	222	Meningiditis-like promoter; A39T
+mtrR	223	A39T
+mtrR	224	A39T
+mtrR	225	A39T
+mtrR	226	Wild-Type
+mtrR	227	Wild-Type
+mtrR	228	Wild-Type
+mtrR	229	Wild-Type
+mtrR	230	A39T
+mtrR	231	Wild-Type
+mtrR	232	-35A Del; G45D
+mtrR	233	AMR Markers -35A Del
+mtrR	234	AMR Markers -35A Del, A39T
+mtrR	235	AMR Markers -35A Del
+mtrR	236	AMR Markers A39T
+mtrR	237	Wild Type
+mtrR	238	Wild Type
+mtrR	239	AMR Markers A39T
+mtrR	240	AMR Markers A39T
+mtrR	241	AMR Markers A39T
+mtrR	242	AMR Markers A39T
+mtrR	243	Wild Type
+mtrR	244	Wild Type
+mtrR	245	AMR Markers A39T
+mtrR	246	AMR Markers A39T
+mtrR	247	AMR Markers A39T
+mtrR	248	AMR Markers -35A Del
+mtrR	249	AMR Markers A39T
+mtrR	250	Wild Type
+mtrR	251	Contains an 8 nucleotide insertion in promoter at about position -10 from start codon; Meningiditis-like promoter
+mtrR	252	A39T
+mtrR	253	Unusual amino acid substitution at position G45; G45S
+mtrR	254	Wild Type
+mtrR	255	Wild Type
+mtrR	256	-35A Del, A39T
+mtrR	257	Wild Type
+mtrR	258	A39T
+mtrR	259	Meningiditis-like promoter, G45D
+mtrR	260	Wild Type
+mtrR	261	A39T
+mtrR	262	Wild Type
+mtrR	263	Wild Type
+mtrR	264	-35A Del, A39T
+mtrR	265	Wild Type
+mtrR	266	-35A Del
+mtrR	267	Disrupted WHO-P like promoter
+mtrR	268	Unusual amino acid substitution at position G4; G45R
+mtrR	269	A39T
+mtrR	270	Wild Type
+mtrR	271	Wild Type
+mtrR	272	A39T
+mtrR	273	A39T
+mtrR	274	A39T
+mtrR	275	G45D
+mtrR	276	A39T
+mtrR	277	A39T
+mtrR	278	Wild Type
+mtrR	279	Wild Type
+mtrR	280	A39T
+mtrR	281	Meningiditis-like promoter
+mtrR	282	-35A Del
+mtrR	283	A39T
+mtrR	284	A39T
+mtrR	285	Meningitidis-like promoter, A39T
+mtrR	286	Wild Type
+mtrR	287	G45D
+mtrR	288	-35A Del
+mtrR	289	G45D
+mtrR	290	Wild-Type
+mtrR	291	Meningitidis-like promoter, -35A Del
+mtrR	292	Wild Type
+mtrR	293	Wild Type
+mtrR	294	Wild Type
+mtrR	295	Meningiditis-like promoter
+mtrR	296	A39T
+mtrR	297	Wild Type
+mtrR	298	A39T
+mtrR	299	Wild Type
+mtrR	300	Wild Type
+mtrR	301	G45D
+mtrR	302	Meningitidis-like promoter, -35A Del
+mtrR	303	-35A Del
+mtrR	304	A39T
+mtrR	305	A39T
+mtrR	306	A39T
+mtrR	307	-35Adel, A39T
+mtrR	308	-35Adel, G45D
+mtrR	309	-35Adel, G45D
+mtrR	310	-35Adel, G45D
+mtrR	311	Meningitidis-like promoter
+mtrR	312	Meningitidis-like promoter, -35A Del
+mtrR	313	-35Adel
+mtrR	314	-35Adel
+mtrR	315	Wild Type
+mtrR	316	A39T
+mtrR	317	-35Adel
+mtrR	318	-35Adel
+mtrR	319	-35Adel, G45D
+mtrR	320	A39T
+mtrR	321	Wild-type
+mtrR	322	A39T
+mtrR	323	G45D
+mtrR	324	Wild-type
+mtrR	325	-35A Del
+mtrR	326	A39T
+mtrR	327	-35A Del; A39T
+mtrR	328	Meningitidis-like promoter
+mtrR	329	Wild-type
+mtrR	330	A39T
+mtrR	331	A39T
+mtrR	332	A39T
+mtrR	333	A39T
+mtrR	334	A39T
+mtrR	335	-35A Del
+mtrR	336	A39T
+mtrR	337	A39T
+mtrR	338	Meningitidis-like promoter
+mtrR	339	-35A Del
+mtrR	340	A39T
+mtrR	341	A39T
+mtrR	342	-35A Del; A39T
+mtrR	343	A39T
+mtrR	344	A39T
+mtrR	345	-35A Del; G45D
+mtrR	346	G45D
+mtrR	347	Wild-type
+mtrR	348	Wild-type
+mtrR	349	A39T
+mtrR	350	Disrupted WHO-P like promoter
+mtrR	351	Wild-Type
+mtrR	352	Meningitidis-like promoter, -35A Del
+mtrR	353	Wild Type
+mtrR	354	A39T
+mtrR	355	Wild Type
+mtrR	356	-35A Del
+mtrR	357	-35A Del, A39T
+mtrR	358	Disrupted WHO-P like promoter
+mtrR	359	Disrupted WHO-P like promoter
+mtrR	360	A39T
+mtrR	361	Wild Type
+mtrR	362	Disrupted WHO-P like promoter
+mtrR	363	Meningitidis-like promoter, -35A Del
+mtrR	364	G45D
+mtrR	365	Wild Type
+mtrR	366	Meningiditis-like promoter
+mtrR	367	-35A Del, A39T
+mtrR	368	A39T
+mtrR	369	Wild Type
+mtrR	370	Meningitidis-like promoter
+mtrR	371	Wild Type
+mtrR	372	-35Adel
+mtrR	373	Meningitidis-like promoter
+mtrR	374	Wild Type
+mtrR	375	G45D
+mtrR	376	Meningitidis-like promoter
+mtrR	377	A39T
+mtrR	378	A39T
+mtrR	379	A39T
+mtrR	380	A39T
+mtrR	381	N. meningiditis-like promoter
+mtrR	382	Wild Type; 6bp Translocation
+mtrR	383	Wild Type; 6bp Translocation
+mtrR	384	Wild-Type
+mtrR	385	Wild-Type
+mtrR	386	Wild-Type
+mtrR	387	Wild-Type
+mtrR	388	A39T
+mtrR	389	Wild-Type
+mtrR	390	Wild-Type
+mtrR	391	A39T
+mtrR	392	A39T
+mtrR	393	A39T
+mtrR	394	Wild-Type
+mtrR	395	Wild-Type
+mtrR	396	-35Adel
+mtrR	397	A39T
+mtrR	398	A39T
+mtrR	399	A39T
+mtrR	400	G45D
+mtrR	401	A39T
+mtrR	402	Wild-Type
+mtrR	403	A39T
+mtrR	404	Disrupted WHO-P like promoter, G45D
+mtrR	405	N. meningitidis-like promoter, 161bp deletion
+mtrR	406	N. meningitidis-like promoter
+mtrR	407	N. meningitidis-like promoter
+mtrR	408	N. meningitidis-like promoter
+mtrR	409	N. meningitidis-like promoter, -35A Del
+mtrR	410	N. meningitidis-like promoter, -35A Del
+mtrR	411	N. meningitidis-like promoter
+mtrR	412	N. meningitidis-like promoter
+mtrR	413	N. meningitidis-like promoter, -35A Del
+mtrR	414	A39T
+mtrR	415	Wild-Type
+mtrR	416	Wild-Type
+mtrR	418	Wild-Type
+mtrR	419	N. meningitidis-like promoter
+mtrR	420	G45D
+mtrR	421	Wild-Type
+mtrR	422	Wild-Type
+mtrR	423	Disrupted WHO-P like promoter
+mtrR	424	Wild-Type, 19bp insertion
+mtrR	425	-35A del
+mtrR	426	Wild-Type
+mtrR	427	Disrupted WHO-P like promoter
+mtrR	428	N. meningitidis-like promoter
+mtrR	429	Wild-Type
+mtrR	430	Wild-Type
+mtrR	431	A39T
+mtrR	432	A39T
+mtrR	433	A39T
+mtrR	434	Wild-Type
+mtrR	435	-35A del
+mtrR	436	N. meningitidis-like promoter
+mtrR	437	A39T
+mtrR	438	-35Adel, G45D
+mtrR	439	Wild-Type
+mtrR	440	N. meningitidis-like promoter
+mtrR	441	Wild-Type
+mtrR	442	-35A del
+mtrR	443	A39T
+mtrR	444	A39T
+mtrR	445	Wild-Type
+mtrR	446	A39T
+mtrR	447	Disrupted
+mtrR	448	A39T
+mtrR	449	Wild-Type
+mtrR	450	Wild-Type
+mtrR	451	A39T
+mtrR	452	-35A Del
+mtrR	453	-35Adel
+mtrR	454	G45D
+mtrR	455	-35Adel
+mtrR	456	G45D
+mtrR	457	A39T
+mtrR	458	A39T
+mtrR	459	A39T
+mtrR	460	Wild-Type
+mtrR	461	A39T
+mtrR	462	A39T
+mtrR	463	Wild-Type
+mtrR	464	A39T
+mtrR	465	Wild-Type
+mtrR	466	Wild-Type
+mtrR	467	Wild-Type
+mtrR	468	Wild-Type
+mtrR	469	Wild-Type
+mtrR	470	Wild-Type
+mtrR	471	-35Adel
+mtrR	472	Wild-Type
+mtrR	473	A39T
+mtrR	474	A39T
+mtrR	475	A39T
+mtrR	476	Wild-Type
+mtrR	477	A39T
+mtrR	478	A39T
+mtrR	479	A39T
+mtrR	480	A39T
+mtrR	481	Wild-Type
+mtrR	482	Wild-Type
+mtrR	483	A39T
+mtrR	484	-35Adel
+mtrR	485	N. meningitidis-like promoter, -35A Del
+mtrR	486	A39T
+mtrR	487	A39T
+mtrR	488	A39T
+mtrR	489	A39T
+mtrR	490	Wild-Type
+mtrR	491	A39T
+mtrR	492	A39T
+mtrR	493	Wild-Type
+mtrR	494	A39T
+mtrR	495	A39T
+mtrR	496	Wild-Type
+mtrR	497	Wild-Type
+mtrR	498	A39T
+mtrR	499	Wild-Type
+mtrR	500	A39T
+mtrR	501	A39T
+mtrR	502	Wild-Type
+mtrR	503	A39T
+mtrR	504	A39T
+mtrR	505	Disrupted WHO-P like promoter
+mtrR	506	Wild-Type
+mtrR	507	Wild-Type
+mtrR	508	A39T
+mtrR	509	A39T
+mtrR	510	Wild-Type
+mtrR	511	N. meningitidis-like promoter
+mtrR	512	A39T
+mtrR	513	N. meningitidis-like promoter
+mtrR	514	Wild-Type
+mtrR	515	Wild-Type
+mtrR	516	Wild-Type
+mtrR	517	Wild-Type
+mtrR	518	N. meningitidis-like promoter
+mtrR	519	N. meningitidis-like promoter
+mtrR	520	Disrupted WHO-P like promoter
+mtrR	521	Wild-Type
+mtrR	522	A39T
+mtrR	523	Wild-Type
+mtrR	524	A39T
+mtrR	525	A39T
+mtrR	526	Wild-Type
+mtrR	528	-35Adel
+mtrR	529	N. meningitidis-like promoter
+mtrR	530	Disrupted WHO-P like promoter, -35A Del
+mtrR	531	-35Adel
+mtrR	532	A39T
+mtrR	533	A39T
+mtrR	534	-35Adel
+mtrR	535	Wild-Type
+mtrR	536	G45D
+mtrR	537	G45D
+mtrR	538	-35Adel, A39T
+mtrR	539	G45D
+mtrR	540	-35Adel, A39T
+mtrR	541	G45D
+mtrR	542	-35Adel
+mtrR	543	A39T
+mtrR	544	Wild-Type
+mtrR	545	G45D
+mtrR	546	Wild-Type
+mtrR	547	Wild-Type
+mtrR	548	A39T
+mtrR	549	Disrupted WHO-P like promoter
+mtrR	550	G45S
+mtrR	551	G45D
+mtrR	552	G45D
+mtrR	553	-35Adel
+mtrR	554	Wild-Type
+mtrR	555	Wild-Type
+mtrR	556	Wild-Type
+mtrR	557	Wild-Type
+mtrR	559	Wild-Type
+mtrR	560	Wild-Type
+porB	1	Wild Type
+porB	2	mutation: A121D
+porB	3	mutation: A121S
+porB	4	mutation: G120D
+porB	5	mutations: G120D, A121D
+porB	6	mutations: G120D, A121N
+porB	7	mutations: G120K, A121D
+porB	8	mutations: G120K, A121D
+porB	9	mutations: G120R, A121D
+porB	10	mutations: G120K, A121D
+porB	11	mutations: G120K, A121N
+porB	12	mutations: G120K, A121G
+porB	13	
+porB	14	
+porB	15	mutations: A120K, A121V
+porB	16	mutation: G120N
+porB	17	mutations: G120N, A121D
+porB	19	porB1a
+porB	20	porB1a
+porB	21	mutations: G120N, A121D
+porB	23	mutation: G120D
+porB	24	mutations: G120N, A121N
+porB	26	mutations: G120K, A121N
+porB	27	mutation: A121N
+porB	29	mutations: G120K, A121N
+porB	30	mutation: G120D
+porB	31	mutations: G120N, A121V
+porB	33	mutations: G120C, A121S
+porB	35	mutation: A121V
+porB	37	mutations: G120N, A121G
+porB	39	Wild-type
+porB	41	mutations: G120D, A121G
+porB	42	mutation: A121S
+porB	43	Wild-type
+porB	44	porB1a
+porB	45	mutations: G120Q, A121N
+porB	46	G120R, A121G
+porB	47	Wild Type
+porB	48	G120K, A121G
+porB	49	G120K, A121G
+porB	50	porB1a
+porB	51	porB1a
+porB	52	Mutation: G120D
+porB	53	Mutations: G120K, A121G
+porB	54	Mutations: G120N, A121V 2 codon deletion results in 2 amino acid frame shift
+porB	55	Mutations: G120N, A121G
+porB	56	mutations: G120K, A121D
+porB	57	mutations: G120E, A121G
+porB	58	G120K, A121G
+porB	59	G120R, A121D
+porB	60	G120K, A121N
+porB	61	porB1a
+porB	62	porB1a
+porB	63	G120S
+porB	64	G120D
+porB	65	G120T, A121D
+porB	66	Mutations: G120D, A121G
+porB	67	G120K, A121D
+porB	68	G120D, A121D
+porB	69	G120D, A121G
+porB	70	G120D
+porB	71	G120R, A121N
+porB	72	G120A
+porB	73	G120T, A121N
+porB	74	A121D
+porB	75	G120D, A121G
+porB	76	A121D
+porB	77	Wild Type
+porB	78	G120N, A121D
+porB	79	G120D, A121D
+porB	100	Wild Type
+ponA	1	mutation: L421P
+ponA	2	wild-type
+ponA	3	mutation: L421P
+ponA	4	mutation: L421P
+ponA	5	mutation: L421P
+ponA	6	mutation: L421P
+ponA	7	Wild-type
+ponA	8	Wild-type
+ponA	9	mutation: L421P
+ponA	10	Wild-type
+ponA	11	L421P
+ponA	12	L421P
+ponA	13	Mutation: L421P
+ponA	14	Mutation: L421P
+ponA	15	Wild Type
+ponA	16	
+ponA	17	Wild_type
+ponA	18	mutation: L421P
+ponA	19	Wild-type
+ponA	100	wild-type
+gyrA	1	mutations: S91F, D95G Ciprofloxacin MIC: 2
+gyrA	2	mutations: S91F, D95N Ciprofloxacin: >32
+gyrA	3	mutation: S91Y Ciprofloxacin: 0.5
+gyrA	4	Wild type
+gyrA	5	mutations: S91F Ciprofloxacin MIC: 0.125
+gyrA	6	Wild type
+gyrA	7	mutations S91F, D95A Ciprofloxacin MIC: 4
+gyrA	8	Wild type
+gyrA	9	mutation: S91F Ciprofloxacin: 2
+gyrA	10	Wild type
+gyrA	11	mutation: S91T
+gyrA	12	mutation: D95N
+gyrA	13	mutation: S91T
+gyrA	14	mutation: D95N
+gyrA	15	mutations: S91F, D95A
+gyrA	16	mutations: S91F, D95Y
+gyrA	17	mutation: S91Y
+gyrA	18	Mutations: S91F, D95G premature stop codon
+gyrA	19	Wild type
+gyrA	20	Wild type
+gyrA	21	mutations: S91F, D95A
+gyrA	22	mutation: D95G
+gyrA	23	mutations: D91F, D95G
+gyrA	24	mutations: S91F, D95G
+gyrA	25	mutations: S91F, D95N
+gyrA	26	mutation: S91T
+gyrA	27	mutation: S91T
+gyrA	30	Mutations: S91F, D95N
+gyrA	31	Mutations: S91F, D95N
+gyrA	32	Mutations: S91F, D95G
+gyrA	33	Mutations: S91F, D95G
+gyrA	34	Mutations: S91F, D95Y
+gyrA	35	Mutation: D95Y
+gyrA	36	Mutation: S91T
+gyrA	37	Mutations: S91F, D95G
+gyrA	38	Mutations: S91F, D95A
+gyrA	39	Mutation: S91T
+gyrA	40	Mutations: S91F, D95A
+gyrA	41	Mutation: S91T
+gyrA	42	Mutation: S91T
+gyrA	43	Wild type
+gyrA	44	Mutation: S91T
+gyrA	45	Mutations: S91F; D95N
+gyrA	46	Wild type
+gyrA	47	mutation: D95A
+gyrA	48	Wild type
+gyrA	49	mutation: S91I
+gyrA	50	Mutations: S91F
+gyrA	51	Wild type
+gyrA	52	mutation: DS91F, D95A
+gyrA	53	mutation: S91T
+gyrA	54	Wild type
+gyrA	55	mutations: S91F, D95A
+gyrA	56	mutations: S91F, D95A
+gyrA	57	mutations: S91F, D95A
+gyrA	58	mutations: S91F, D95A
+gyrA	59	Wild type
+gyrA	60	mutation: S91T
+gyrA	61	mutation: S91I
+gyrA	62	mutations: S91F, D95H
+gyrA	100	Wild type
+parC	1	Wild Type
+parC	2	Wild Type
+parC	3	mutations: S87R
+parC	4	mutation: D86N
+parC	5	mutations: S87R, S88P
+parC	6	Wild Type
+parC	7	Wild Type
+parC	8	mutation: S87N
+parC	9	mutation: D86N
+parC	10	Wild Type
+parC	11	mutations: D86N, S88P
+parC	12	mutation: S87I
+parC	13	mutation: S87N
+parC	14	mutation: S87R
+parC	15	mutation: S87N
+parC	16	mutation: S87R
+parC	17	Wild Type
+parC	18	mutation: D86N
+parC	19	Wild Type
+parC	20	mutation: S87N
+parC	21	Wild-type
+parC	22	Wild-type
+parC	23	mutations: S87R
+parC	24	mutations: S87I
+parC	25	mutations: S87R
+parC	26	mutations: S87N
+parC	27	Wild-type
+parC	28	mutation: D86N
+parC	29	mutation: S88P
+parC	30	Wild-type
+parC	31	mutation: S87N
+parC	32	Wild-type
+parC	33	mutation: S87N
+parC	34	Wild-type
+parC	35	Wild-type
+parC	36	Wild-type
+parC	37	Wild-type
+parC	38	Wild-type
+parC	39	mutations: S87R; S88P
+parC	40	Wild-type
+parC	41	mutation: S88P
+parC	42	Wild-type
+parC	43	mutation: S87N
+parC	44	Wild-type
+parC	45	mutation: S87I
+parC	46	Wild-type
+parC	47	mutation: S87R
+parC	48	mutation: S87I
+parC	49	Wild-type
+parC	50	Wild-type
+parC	51	mutation: S88P
+parC	52	Wild-type
+parC	53	mutation: S87C
+parC	54	Wild-type
+parC	55	mutation: S87N
+parC	56	Wild-type
+parC	57	Wild-type
+parC	58	Wild-type
+parC	59	mutations: D86N, S87I
+parC	60	Wild-type
+parC	61	mutation: S88P
+parC	62	mutation: D86N
+parC	63	Wild Type
+parC	64	mutation: S88P
+parC	65	mutation: S87N
+parC	66	mutation: S87R
+parC	67	Wild Type
+parC	68	Wild Type
+parC	69	Wild Type
+parC	70	Wild Type
+parC	71	Wild Type
+parC	72	mutation: S88P
+parC	73	Wild Type
+parC	74	mutation: S87R
+parC	75	mutation: S87N
+parC	76	mutation: S87R
+parC	77	mutation: S88P
+parC	78	mutation: D86N
+parC	79	mutation: S87N
+parC	80	mutation: S87N
+parC	81	mutation: S87N
+parC	82	mutation: S87R
+parC	83	mutation: D86N
+parC	84	mutation: D86N
+parC	85	mutations: D87R; S88P
+parC	86	mutation: D86N
+parC	87	Mutations: S87N, E91K
+parC	88	Mutation: D86N
+parC	89	Wild Type
+parC	90	Mutation: E91G
+parC	91	Mutations: S87N, S88P
+parC	92	Wild Type
+parC	93	Mutation: S87N
+parC	94	Mutations: S87C, E91G
+parC	95	Mutation: S87N
+parC	96	Wild Type
+parC	97	Mutation: S87N
+parC	98	Mutations: S87N, E91Q
+parC	99	Wild Type
+parC	100	Wild-type
+parC	101	Wild Type
+parC	102	Mutations: S87I, E91G
+parC	103	Mutation: S87N
+parC	104	Mutation: S87R
+parC	105	Mutation: S87R
+parC	106	Wild Type
+parC	107	Wild Type
+parC	108	Mutation: S87R
+parC	109	Mutation: S87R
+parC	110	Mutation: S87N
+parC	111	Mutation: S87R
+parC	112	Wild Type
+parC	113	Mutation: S87N
+parC	114	Mutation: S88P
+parC	115	Mutation: S87N
+parC	116	Mutation: D86N
+parC	117	Mutation: S87R
+parC	118	Mutation: E91Q
+parC	119	Wild Type
+parC	120	Mutation: S87R
+parC	121	Mutation: S87R
+parC	122	Mutation: S87I
+parC	123	Mutations: D86N, S87N
+parC	124	Mutation: S87R
+parC	125	Mutation: E91A
+parC	126	Mutations: S88P, E91Q
+parC	128	Mutation: S87R
+parC	129	Mutations: S87K, S88A
+parC	130	Mutations: S87N; E91K
+parC	131	Mutation: S87I
+parC	132	Mutations: S87N; E91K
+parC	133	Mutation: S87R
+parC	134	Mutation: S87Y
+parC	135	Wild Type
+parC	136	Wild Type
+parC	137	Mutation: D86N
+parC	138	Mutation: S87R
+parC	139	Mutations: S87N; S88P
+parC	140	Mutations: S87N; E91G
+parC	141	Mutation: E91Q
+parC	142	Wild Type
+parC	143	Mutation: S87R
+parC	144	Mutation: S87N
+parC	145	Wild Type
+parC	146	Mutation: D86N
+parC	147	mutation: E91G
+parC	148	Wild-type
+parC	149	Mutations: E91G
+parC	150	mutations: S87N, S88P
+parC	151	mutations: S87N, S88P, E91G
+parC	152	Wild type
+parC	153	mutation: S87R
+parC	154	Wild type
+parC	155	mutation: D86N
+parC	156	mutation: E91G
+parC	157	mutation: D86N
+parC	158	mutation: S87R
+parC	159	mutation: D86N
+parC	160	mutations: S87R, S88P
+parC	161	mutation: S87R
+parC	162	mutation: S87I
+parC	163	mutations: D86G, E91G
+parC	164	mutation: S87R
+parC	165	mutation: S87R
+parC	166	mutation: S87R
+parC	167	mutation: S87N
+parC	168	mutations: S87C, E91A
+parC	169	mutations: S87N, E91Q
+parC	170	mutation: S87R
+parC	171	mutation: D86N
+parC	172	mutation: S87I
+parC	174	mutation: S87I
+parC	175	Wild type
+parC	176	mutation: S87R
+parC	177	mutation: S87R
+parC	178	Wild type
+parC	179	Wild type
+parC	180	Wild type
+parC	181	mutation: S87R
+parC	182	Wild type
+parC	183	mutations: S87N, E91Q
+parC	184	Wild Type
+parC	185	Mutations: D86N, S88P
+parC	186	Mutation: S87I
+parC	187	Mutation: S87I
+23S	1	A2059G Azithromycin MIC:>=512 Erythromycin MIC:>=64
+23S	2	C2611T Azithromycin MIC:4 Erythromycin MIC: 32
+23S	3	Wild_type
+23S	4	Wild_type
+23S	5	Wild_type
+23S	6	Wild_type
+23S	7	C2611T Azithromycin MIC: 4 Erythromycin MIC: >=64
+23S	8	Wild_type
+23S	9	Wild_type
+23S	10	Wild-type
+23S	11	Wild_type
+23S	12	Wild_type
+23S	13	Wild_type
+23S	14	Wild_type
+23S	15	Wild_type
+23S	16	C2611T
+23S	17	Wild_type
+23S	18	Wild-type
+23S	19	Wild_type
+23S	20	Wild_type
+23S	21	Wild_type
+23S	22	Wild_type
+23S	23	Wild_type
+23S	24	Wild_type
+23S	25	Wild_type
+23S	26	Wild_type
+23S	27	Wild_type
+23S	28	Wild_type
+23S	29	Wild_type
+23S	30	Wild_type
+23S	31	Wild_type
+23S	32	Wild_type
+23S	33	Wild_type
+23S	34	Wild_type
+23S	35	Wild_type
+23S	36	Wild_type
+23S	37	Wild_type
+23S	38	Mutation: A2059G
+23S	39	Wild_type
+23S	40	Wild_type
+23S	41	Mutation: C2611G
+23S	42	Wild_type
+23S	43	Wild_type
+23S	44	Wild_type
+23S	45	Wild_type
+23S	46	Wild_type
+23S	47	Wild_type
+23S	48	Wild_type
+23S	49	Wild_type
+23S	50	Wild_type
+23S	51	unknown
+23S	52	AMR marker unknown
+23S	53	Wild-Type
+23S	54	Wild-Type
+23S	55	Wild-Type
+23S	56	Wild-Type
+23S	57	Wild-Type
+23S	58	Wild-Type
+23S	59	Wild-Type
+23S	60	Wild-Type
+23S	61	Wild-Type
+23S	62	Wild-Type
+23S	63	Wild-Type
+23S	64	Wild-Type
+23S	65	Wild-Type
+23S	66	C2611T
+23S	67	Wild-Type
+23S	68	Wild-Type
+23S	69	Wild-Type
+23S	70	C2611T
+23S	71	Wild-Type
+23S	72	Wild-Type
+23S	73	Wild-Type
+23S	74	Wild-Type
+23S	75	Wild-Type
+23S	76	Wild-Type
+23S	77	Wild-Type
+23S	78	Wild-Type
+23S	100	Wild_type


### PR DESCRIPTION
This pull request fixes the issue where the `--comments` flag was not working in `ngmaster`. The `allele_comments.tsv` file was missing in the ngstar database. This PR adds the missing `allele_comments.tsv` file to the ngstar database.
