### PR TITLE
Fix mincov minid arg passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-05-26
+
+### Fixed
+
+- Corrected `--minid` and `--mincov` argparse definitions: removed `nargs=1` and added `type=int` so both flags always produce a scalar integer. Previously, `nargs=1` caused argparse to return a list when the user supplied a value (e.g. `--mincov 20` produced `[20]`), which `str()` serialised as `"['20']"`, an argument that mlst rejects with a non-zero exit code (#39).
+- Improved error reporting when an mlst subprocess fails: mlst's own stderr output is now relayed to the user via `msg()` before ngmaster exits, so the root cause is visible rather than just the command-line dump and exit code (#57).
+- Added `TestMinidMincov` integration tests covering scalar value passing, combined flag usage, invalid type rejection, and mlst stderr surfacing.
+
 ## [2.0.2] - 2026-05-25
 
 ### Security

--- a/ngmaster/__init__.py
+++ b/ngmaster/__init__.py
@@ -1,5 +1,5 @@
 # Script by Jason Kwong & Torsten Seemann
 # In silico multi-antigen sequence typing for Neisseria gonorrhoeae (NG-MAST)
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 

--- a/ngmaster/run_ngmaster.py
+++ b/ngmaster/run_ngmaster.py
@@ -89,8 +89,8 @@ def main():
         f'default: {Path(__file__).parent / "db"}\n')
     parser.add_argument('--csv', action='store_true', default=False, help='output comma-separated format (CSV) rather than tab-separated')
     parser.add_argument('--printseq', metavar='FILE', nargs=1, help='specify filename to save allele sequences to')
-    parser.add_argument('--minid', metavar='MINID', nargs=1, default=95, help='DNA percent identity of full allele to consider \'similar\' [~]')
-    parser.add_argument('--mincov', metavar='MINCOV', nargs=1, default=10, help='DNA percent coverage to report partial allele at [?]')
+    parser.add_argument('--minid', metavar='MINID', type=int, default=95, help='DNA percent identity of full allele to consider \'similar\' [~]')
+    parser.add_argument('--mincov', metavar='MINCOV', type=int, default=10, help='DNA percent coverage to report partial allele at [?]')
     parser.add_argument('--updatedb', action='store_true', default=False, help='update NG-MAST and NG-STAR allele databases from <https://rest.pubmlst.org/db/pubmlst_neisseria_seqdef>')
     parser.add_argument('--assumeyes', action='store_true', default=False, help='assume you are certain you wish to update db')
     parser.add_argument('--test', action='store_true', default=False, help='run test example')
@@ -220,7 +220,9 @@ def main():
                 scheme, scheme_output = future.result()
                 output[scheme] = scheme_output
             except CalledProcessError as e:
-                raise SystemExit(e)
+                if e.stderr and e.stderr.strip():
+                    msg(e.stderr.strip())
+                err(str(e))
 
     # Collate results from two runs
     collate_out = collate_results(output['ngmast'], output['ngstar'], ttable, ngstartbl)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -356,3 +356,65 @@ class TestRegression:
     def test_builtin_test_no_traceback(self):
         _no_traceback(_run("--test"))
 
+
+# ---------------------------------------------------------------------------
+# 8. Regression: --minid / --mincov flag passing  (issue #39 / #57)
+# ---------------------------------------------------------------------------
+
+class TestMinidMincov:
+    """Regression tests for issue #39 (nargs=1 caused list-as-string to be passed to mlst)
+    and issue #57 (mlst stderr not surfaced on failure).
+    """
+
+    def test_minid_flag_exits_zero(self):
+        """--minid must be accepted as a scalar value and passed correctly to mlst."""
+        result = _run("--minid", "85", _TEST_FA)
+        assert result.returncode == 0, (
+            f"--minid 85 failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        _no_traceback(result)
+
+    def test_mincov_flag_exits_zero(self):
+        """--mincov must be accepted as a scalar value and passed correctly to mlst."""
+        result = _run("--mincov", "15", _TEST_FA)
+        assert result.returncode == 0, (
+            f"--mincov 15 failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        _no_traceback(result)
+
+    def test_minid_mincov_combined_exits_zero(self):
+        """Combining --minid and --mincov must produce the correct ST."""
+        result = _run("--minid", "85", "--mincov", "15", _TEST_FA)
+        assert result.returncode == 0, (
+            f"--minid 85 --mincov 15 failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        _no_traceback(result)
+        assert "4186/231" in result.stdout
+
+    def test_minid_invalid_type_exits_nonzero(self):
+        """Non-integer --minid must exit non-zero with no Python traceback (issue #57)."""
+        result = _run("--minid", "notanumber", _TEST_FA)
+        assert result.returncode != 0
+        _no_traceback(result)
+
+    def test_mincov_invalid_type_exits_nonzero(self):
+        """Non-integer --mincov must exit non-zero with no Python traceback (issue #57)."""
+        result = _run("--mincov", "notanumber", _TEST_FA)
+        assert result.returncode != 0
+        _no_traceback(result)
+
+    def test_mlst_stderr_surfaced_on_failure(self):
+        """When mlst fails, its stderr must appear in ngmaster stderr (issue #57).
+
+        null.fa is an empty file that causes mlst to exit non-zero with a
+        descriptive error message. ngmaster must relay that message to stderr
+        rather than only showing the CalledProcessError exception summary.
+        """
+        result = _run(_NULL_FA)
+        assert result.returncode != 0
+        _no_traceback(result)
+        # mlst writes its own error to stderr; ngmaster must relay it.
+        assert result.stderr.strip() != "", (
+            "Expected mlst error message in stderr, but stderr was empty."
+        )
+


### PR DESCRIPTION
## Summary

Fixes:
- Argument parsing bug for `--minid` and `--mincov` flags in `run_ngmaster.py` (always returns an integer, not a list). Closes #39.
- Sub-tool (mlst) error messages are now shown to the user when a subprocess fails. Closes #57.

## Tests

- Added tests in `tests/test_cli.py` for correct flag handling, error handling, and stderr output.
- All integration and unit tests pass.