### PR TITLE
Add JSON output support to ngmaster

### DIFF
--- a/ngmaster/run_ngmaster.py
+++ b/ngmaster/run_ngmaster.py
@@ -111,6 +111,7 @@ def main():
         'overrides $NGMASTER_DB environment variable if both are set\n'
         f'default: $NGMASTER_DB if set, otherwise {Path(__file__).parent / "db"}\n')
     parser.add_argument('--csv', action='store_true', default=False, help='output comma-separated format (CSV) rather than tab-separated')
+    parser.add_argument('--json', action='store_true', default=False, help='output JSON format rather than tab-separated')
     parser.add_argument('--printseq', metavar='FILE', nargs=1, help='specify filename to save novel allele sequences to\n'
         '(only alleles marked ~n are written; no file created if all alleles are exact matches)')
     parser.add_argument('--minid', metavar='MINID', type=int, default=95, help='DNA percent identity of full allele to consider \'similar\' [~] (default: 95, range: 0-100)')
@@ -294,10 +295,17 @@ def main():
     else:
         header = ['FILE', 'SCHEME', 'NG-MAST/NG-STAR', 'porB_NG-MAST', 'tbpB', 'penA', 'mtrR', 'porB_NG-STAR', 'ponA', 'gyrA', 'parC', '23S', 'CC']  # Add CC column
 
-    print(SEP.join(header))
-
-    for out in collate_out: 
-        print(out.get_record(sep = SEP, comments = ngstar_comments))
+    if args.json:
+        import json
+        json_out = []
+        for out in collate_out:
+            record_list = out.get_list(comments=ngstar_comments, header=header)
+            json_out.append(dict(zip(header, record_list)))
+        print(json.dumps(json_out, indent=2))
+    else:
+        print(SEP.join(header))
+        for out in collate_out: 
+            print(out.get_record(sep = SEP, comments = ngstar_comments))
     
     if args.test:
         if collate_out[0].st != '4186/231':

--- a/ngmaster/utils.py
+++ b/ngmaster/utils.py
@@ -62,33 +62,33 @@ class MlstRecord:
         # n,m     multiple alleles         
 
  
-    def get_record(self, sep='\t', comments=None, header=None): # FLAG: modified function to deal with wrong number of fields in output
+    def get_list(self, comments=None, header=None):
         '''
-        Function that returns a comma-separated or tab-separated string of allele IDs
-        (and optionally associated PubMLST comments) for each record
+        Function that returns a list of values for each record
         '''
-        
         ngmast_loci = self.alleles[:2]
         ngstar_loci = self.alleles[2:]
-        # print(f"DEBUG: ngmast_loci: {ngmast_loci}, ngstar_loci: {ngstar_loci}") # FLAG: for debugging
         if comments:
             out = [self.fname, self.scheme, self.st] + self.alleles
             # Interleave alleles and comments
             out_with_comments = []
-            # print(f"DEBUG: out: {out}") # FLAG: for debugging
             for i, allele in enumerate(ngstar_loci):  # Assuming 7 loci
-                # Get the corresponding header if provided
-                column_header = header[3 + 2 * i] if header else f"Allele_{i + 1}"
-                comment_header = header[4 + 2 * i] if header else f"Comment_{i + 1}"
                 comment = comments[i].get(allele, "")
-                # Debugging: Log the header, allele, and comment
-                # print(f"DEBUG: {column_header}: {allele}, {comment_header}: {comment}")
                 out_with_comments.append(allele)
                 out_with_comments.append(comment)
             out = out[:5] + out_with_comments
             out.append(self.cc)  # Add CC to output
         else:
             out = [self.fname, self.scheme, self.st] + self.alleles + [self.cc]  # Add CC to output
+        return out
+
+    def get_record(self, sep='\t', comments=None, header=None): # FLAG: modified function to deal with wrong number of fields in output
+        '''
+        Function that returns a comma-separated or tab-separated string of allele IDs
+        (and optionally associated PubMLST comments) for each record
+        '''
+        
+        out = self.get_list(comments=comments, header=header)
 
         # **Handle special characters for CSV output**
         if sep == ',':

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -457,3 +457,30 @@ class TestMinidMincov:
         assert result.stderr.strip() != "", (
             "Expected mlst error message in stderr, but stderr was empty."
         )
+
+# ---------------------------------------------------------------------------
+# 9. JSON Output Format
+# ---------------------------------------------------------------------------
+
+class TestJsonOutput:
+    def test_exits_zero(self):
+        result = _run("--db", _BUNDLED_DB, "--json", _TEST_FA)
+        assert result.returncode == 0
+
+    def test_is_valid_json(self):
+        import json
+        result = _run("--db", _BUNDLED_DB, "--json", _TEST_FA)
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert "CC" in data[0]
+        assert data[0]["NG-MAST/NG-STAR"] == "4186/231"
+        assert data[0]["FILE"].endswith("test.fa")
+
+    def test_json_with_comments(self):
+        import json
+        result = _run("--db", _BUNDLED_DB, "--json", "--comments", _TEST_FA)
+        data = json.loads(result.stdout)
+        assert len(data) == 1
+        assert "penA_comments" in data[0]
+        assert "23S_comments" in data[0]


### PR DESCRIPTION
This PR adds JSON output support to `ngmaster` to comply with the new PAJEFE metadata guidelines.

Addresses #47

The changes generate the output as a JSON array of objects with `--json` flag, including the `--comments` fields when specified. 

**Testing:**
- All tests passing: `pixi run pytest tests/test_cli.py -k TestJsonOutput -v`
